### PR TITLE
refactor(api): Definir contrato de API para desacoplamiento UI-Core

### DIFF
--- a/include/api/ApiDTOs.h
+++ b/include/api/ApiDTOs.h
@@ -1,0 +1,50 @@
+#include <string>
+#include <vector>
+
+/**
+ * @file ApiDTOs.h
+ * @brief Definición de estructuras de datos para la API del sistema de pedidos.
+ * Estas estructuras son utilizadas para transferir información entre
+ * diferentes componentes del sistema, como la interfaz de usuario y el núcleo del sistema.
+ */
+
+//-------------------------------------------------
+// ESTRUCTURAS DE DATOS PARA LA API
+//-------------------------------------------------
+
+struct InfoProducto
+{
+    int id;
+    std::string nombre;
+    double precio;
+};
+
+struct InfoDescuento
+{
+    std::string id_descuento; // Ej: "2X1_BEBIDAS"
+    std::string descripcion;  // Ej: "2x1 en Bebidas"
+};
+
+// Datos que la UI necesita para *crear* un item
+struct ItemPedidoCrear
+{
+    int productoId;
+    int cantidad;
+};
+
+// Datos que la UI necesita para *mostrar* un item
+struct ItemPedidoInfo
+{
+    std::string nombreProducto;
+    int cantidad;
+    double precioUnitario;
+};
+
+struct InfoPedido
+{
+    int id_pedido;
+    std::string cliente;
+    std::string estado; // Ej: "En Cola", "En Preparación", "Listo"
+    std::vector<ItemPedidoInfo> items;
+    double total_final;
+};

--- a/include/api/ICoreSistema.h
+++ b/include/api/ICoreSistema.h
@@ -1,0 +1,44 @@
+#include <vector>
+#include "IObservadorCore.h"
+#include "ApiDTOs.h"
+
+class ICoreSistema
+{
+public:
+    virtual ~ICoreSistema() = default;
+
+    // --- Gestion de Observadores
+    virtual void registrarObservador(IObservadorCore *observador) = 0;
+    virtual void removerObservador(IObservadorCore *observador) = 0;
+
+    // --- Funciones "Vista Cajero"
+
+    /**
+     * Obtiene el menú completo de productos disponibles.
+     */
+    virtual std::vector<InfoProducto> getMenu() = 0;
+
+    /**
+     * Obtiene la lista de descuentos disponibles.
+     */
+    virtual std::vector<InfoDescuento> getDescuentosDisponibles() = 0;
+
+    /**
+     * Finaliza y paga un pedido, encolandolo para la cocina.
+     */
+    virtual void finalizarPedido(const std::string &cliente,
+                                 const std::vector<ItemPedidoCrear> &items,
+                                 const std::vector<std::string> &descuentos) = 0;
+
+    // --- Funciones "Vista Cocina"
+    /**
+     * Obtiene la lista de pedidos que están en cola para ser preparados.
+     */
+    virtual std::vector<InfoPedido> getPedidosEnCola() = 0;
+
+    /**
+     * Intentar procesar el siguiente pedido en cola.
+     * Esto conecta la logica del 'Cocinero' y el 'std::thread'.
+     */
+    virtual void procesarSiguientePedido() = 0;
+};

--- a/include/api/IObservadorCore.h
+++ b/include/api/IObservadorCore.h
@@ -1,0 +1,29 @@
+#include <string>
+
+/**
+ * @file IObservadorCore.h
+ * @brief Interfaz para que la UI observe eventos del núcleo del sistema de pedidos.
+ * Esta interfaz define los métodos que la UI debe implementar para recibir
+ * notificaciones sobre cambios en el estado de los pedidos.
+ */
+
+class IObservadorCore
+{
+public:
+    virtual ~IObservadorCore() = default;
+
+    /**
+     * Notifica a la UI que la cola de pedidos ha cambiado.
+     */
+    virtual void onNuevosPedidosEnCola() = 0;
+
+    /**
+     * Notifica a la UI que un pedido específico está listo.
+     */
+    virtual void onPedidoTerminado(int id_pedido) = 0;
+
+    /**
+     * Notifica a la UI que algo salió mal.
+     */
+    virtual void onError(const std::string &mensaje) = 0;
+};


### PR DESCRIPTION
Define la interfaz abstracta (Contrato API) que separa el Frontend (UI) del Backend (Core).

- Añade 'ICoreSistema.h' (interfaz de entrada al Core).
- Añade 'IObservadorCore.h' (interfaz de salida del Core).
- Añade 'ApiDTOs.h' (structs DTO para la transferencia de datos).

Closes #1 