### PR TITLE
Migración básica a arquitectura Cliente–Servidor: protocolo JSON + framing, comandos GET_MENU / ADD_ORDER, NetworkServer y NetworkClientProxy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ enable_testing()
 
 add_subdirectory(common)
 add_subdirectory(server)
-#add_subdirectory(client)
+add_subdirectory(client)
 
 #Tests
 add_subdirectory(tests)

--- a/archived/test_get_menu_client.py
+++ b/archived/test_get_menu_client.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Script de prueba mínimo que conecta al servidor TCP en localhost:1234,
+envia un request GET_MENU y muestra la respuesta JSON.
+"""
+import socket
+import json
+import struct
+
+HOST = '127.0.0.1'
+PORT = 1234
+
+req = {
+    "cmd": "GET_MENU",
+    "payload": {}
+}
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(5.0)
+try:
+    s.connect((HOST, PORT))
+    payload = json.dumps(req).encode('utf-8')
+    header = struct.pack('>I', len(payload))
+    s.sendall(header + payload)
+
+    # Leer framing: primero 4 bytes de longitud, luego el body
+    try:
+        hdr = s.recv(4)
+        if len(hdr) < 4:
+            print("No se recibió la cabecera completa")
+        else:
+            msg_len = struct.unpack('>I', hdr)[0]
+            data = b""
+            while len(data) < msg_len:
+                chunk = s.recv(msg_len - len(data))
+                if not chunk:
+                    break
+                data += chunk
+            try:
+                parsed = json.loads(data.decode('utf-8'))
+                print(json.dumps(parsed, indent=2, ensure_ascii=False))
+            except Exception as e:
+                print("No se pudo parsear la respuesta:", e)
+    except socket.timeout:
+        print("No se recibió respuesta (timeout)")
+finally:
+    s.close()

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Network)
 
 set(PROJECT_SOURCES
     src/main.cpp
@@ -19,11 +19,16 @@ set(PROJECT_SOURCES
     src/mainwindow.ui
     src/CoreQtAdapter.h
     src/CoreQtAdapter.cpp
+    src/NetworkClientProxy.cpp
+    src/NetworkProtocol.h
 )
 
 add_executable(CafeteriaClient
     ${PROJECT_SOURCES}
 )
+
+add_executable(TestNetworkProxy src/test_network_proxy.cpp src/NetworkClientProxy.cpp src/NetworkProtocol.h)
+target_link_libraries(TestNetworkProxy PRIVATE Qt${QT_VERSION_MAJOR}::Network Qt${QT_VERSION_MAJOR}::Core CafeteriaCommon)
 
 target_link_libraries(CafeteriaClient PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Network)
 

--- a/client/src/NetworkClientProxy.cpp
+++ b/client/src/NetworkClientProxy.cpp
@@ -1,0 +1,174 @@
+#include "NetworkClientProxy.h"
+
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QDataStream>
+#include <QHostAddress>
+#include <QDebug>
+
+#include "../../common/include/api/Protocolo.h"
+
+#include "NetworkProtocol.h"
+
+NetworkClientProxy::NetworkClientProxy(const QString &host_, quint16 port_)
+    : host(host_), port(port_)
+{
+    socket = new QTcpSocket();
+    socket->connectToHost(host, port);
+    if (!socket->waitForConnected(2000)) {
+        qWarning() << "NetworkClientProxy: no se pudo conectar a" << host << port;
+    }
+}
+
+NetworkClientProxy::~NetworkClientProxy()
+{
+    if (socket) {
+        socket->disconnectFromHost();
+        socket->deleteLater();
+    }
+}
+
+void NetworkClientProxy::registrarObservador(std::shared_ptr<IObservadorCore> /*observador*/)
+{
+    // No-op: observadores serán gestionados por la UI localmente o vía push events en fases posteriores
+}
+
+void NetworkClientProxy::removerObservador(IObservadorCore * /*observador*/)
+{
+    // No-op
+}
+
+QJsonObject NetworkClientProxy::enviarRequestYEsperarRespuesta(const QString &cmd, const QJsonObject &payload, int timeoutMs)
+{
+    if (!socket || socket->state() != QAbstractSocket::ConnectedState) {
+        throw std::runtime_error("No conectado al servidor");
+    }
+
+    // Construir mensaje
+    QJsonObject req;
+    req.insert(Protocolo::KEY_CMD, cmd);
+    req.insert(Protocolo::KEY_PAYLOAD, payload);
+
+    // Enviar
+    NetworkProtocol::sendJson(socket, req);
+
+    // Leer cabecera (4 bytes big-endian)
+    QByteArray hdr;
+    int waited = 0;
+    while (hdr.size() < static_cast<int>(sizeof(quint32)) && waited < timeoutMs) {
+        if (!socket->waitForReadyRead(100)) { waited += 100; continue; }
+        hdr.append(socket->read(static_cast<int>(sizeof(quint32)) - hdr.size()));
+    }
+    if (hdr.size() < static_cast<int>(sizeof(quint32))) {
+        throw std::runtime_error("Timeout esperando cabecera de respuesta");
+    }
+
+    QDataStream ds(hdr);
+    ds.setByteOrder(QDataStream::BigEndian);
+    quint32 len = 0;
+    ds >> len;
+    qDebug() << "NetworkClientProxy: respuesta len=" << len;
+    int availableNow = socket->bytesAvailable();
+    qDebug() << "NetworkClientProxy: bytesAvailable after header:" << availableNow;
+
+    QByteArray body;
+        if (availableNow >= static_cast<int>(len)) {
+            body = socket->read(static_cast<int>(len));
+            qDebug() << "NetworkClientProxy: read full body immediately, size" << body.size();
+        } else {
+            waited = 0;
+            while (body.size() < static_cast<int>(len) && waited < timeoutMs) {
+                if (!socket->waitForReadyRead(100)) { waited += 100; continue; }
+                QByteArray chunk = socket->read(static_cast<int>(len) - body.size());
+                qDebug() << "NetworkClientProxy: read chunk size" << chunk.size();
+                body.append(chunk);
+            }
+        }
+    if (body.size() < static_cast<int>(len)) {
+        throw std::runtime_error("Timeout esperando cuerpo de respuesta");
+    }
+
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(body, &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        throw std::runtime_error(std::string("Respuesta JSON malformada: ") + err.errorString().toStdString());
+    }
+
+    return doc.object();
+}
+
+std::vector<InfoProducto> NetworkClientProxy::getMenu()
+{
+    QJsonObject payload; // vacío
+    QJsonObject resp = enviarRequestYEsperarRespuesta(Protocolo::CMD_GET_MENU, payload);
+    if (!resp.contains(Protocolo::KEY_STATUS) || !resp.value(Protocolo::KEY_STATUS).isString()) {
+        throw std::runtime_error("Respuesta sin status");
+    }
+    QString status = resp.value(Protocolo::KEY_STATUS).toString();
+    if (status != "OK") {
+        QString msg = resp.contains(Protocolo::KEY_MSG) ? resp.value(Protocolo::KEY_MSG).toString() : QString("Error desconocido");
+        throw std::runtime_error(msg.toStdString());
+    }
+
+    std::vector<InfoProducto> menu;
+    if (resp.contains(Protocolo::KEY_DATA) && resp.value(Protocolo::KEY_DATA).isArray()) {
+        QJsonArray arr = resp.value(Protocolo::KEY_DATA).toArray();
+        for (const QJsonValue &v : arr) {
+            if (!v.isObject()) continue;
+            QJsonObject o = v.toObject();
+            InfoProducto p;
+            p.id = o.value("id").toInt();
+            p.nombre = o.value("nombre").toString().toStdString();
+            p.precio = o.value("precio").toDouble();
+            menu.push_back(p);
+        }
+    }
+    return menu;
+}
+
+void NetworkClientProxy::finalizarPedido(const std::string &cliente, const std::vector<ItemPedidoCrear> &items, const std::string &id_descuentos)
+{
+    QJsonObject payload;
+    payload.insert("cliente", QString::fromStdString(cliente));
+    payload.insert("id_descuento", QString::fromStdString(id_descuentos));
+
+    QJsonArray arr;
+    for (const auto &it : items) {
+        QJsonObject o;
+        o.insert("productoId", it.productoId);
+        o.insert("cantidad", it.cantidad);
+        arr.append(o);
+    }
+    payload.insert("items", arr);
+
+    QJsonObject resp = enviarRequestYEsperarRespuesta(Protocolo::CMD_ADD_ORDER, payload);
+    if (!resp.contains(Protocolo::KEY_STATUS) || !resp.value(Protocolo::KEY_STATUS).isString()) {
+        throw std::runtime_error("Respuesta sin status");
+    }
+    QString status = resp.value(Protocolo::KEY_STATUS).toString();
+    if (status != "OK") {
+        QString msg = resp.contains(Protocolo::KEY_MSG) ? resp.value(Protocolo::KEY_MSG).toString() : QString("Error desconocido");
+        throw std::runtime_error(msg.toStdString());
+    }
+}
+
+// Minimal stubs for other methods to satisfy the interface
+std::vector<InfoDescuento> NetworkClientProxy::getDescuentosDisponibles()
+{
+    return {};
+}
+
+double NetworkClientProxy::getPorcentajeIGV() const
+{
+    return 0.0;
+}
+
+std::vector<InfoPedido> NetworkClientProxy::getPedidosActivos()
+{
+    return {};
+}
+
+void NetworkClientProxy::procesarSiguientePedido()
+{
+}

--- a/client/src/NetworkClientProxy.h
+++ b/client/src/NetworkClientProxy.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QObject>
+#include <QTcpSocket>
+#include <vector>
+#include <memory>
+#include <stdexcept>
+
+#include "../../common/include/api/ICoreSistema.h"
+
+class NetworkClientProxy : public ICoreSistema
+{
+public:
+    explicit NetworkClientProxy(const QString &host = QStringLiteral("127.0.0.1"), quint16 port = 1234);
+    ~NetworkClientProxy() override;
+
+    // ICoreSistema implementation (minimal for now)
+    void registrarObservador(std::shared_ptr<IObservadorCore> observador) override;
+    void removerObservador(IObservadorCore *observador) override;
+
+    std::vector<InfoProducto> getMenu() override;
+    std::vector<InfoDescuento> getDescuentosDisponibles() override;
+    double getPorcentajeIGV() const override;
+    void finalizarPedido(const std::string &cliente,
+                         const std::vector<ItemPedidoCrear> &items,
+                         const std::string &id_descuentos) override;
+
+    std::vector<InfoPedido> getPedidosActivos() override;
+    void procesarSiguientePedido() override;
+
+private:
+    QTcpSocket *socket = nullptr;
+    QString host;
+    quint16 port = 0;
+
+    // Helper: send request and wait for a single framed JSON response
+    QJsonObject enviarRequestYEsperarRespuesta(const QString &cmd, const QJsonObject &payload, int timeoutMs = 3000);
+};

--- a/client/src/NetworkProtocol.h
+++ b/client/src/NetworkProtocol.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QTcpSocket>
+#include <QJsonDocument>
+#include <QDataStream>
+
+namespace NetworkProtocol
+{
+    inline void sendJson(QTcpSocket *socket, const QJsonObject &obj)
+    {
+        if (!socket)
+            return;
+        QJsonDocument d(obj);
+        QByteArray payload = d.toJson(QJsonDocument::Compact);
+
+        QByteArray out;
+        QDataStream ds(&out, QIODevice::WriteOnly);
+        ds.setByteOrder(QDataStream::BigEndian);
+        ds << static_cast<quint32>(payload.size());
+        out.append(payload);
+
+        if (socket->isOpen())
+        {
+            socket->write(out);
+            socket->flush();
+        }
+    }
+
+} // namespace NetworkProtocol

--- a/client/src/test_network_proxy.cpp
+++ b/client/src/test_network_proxy.cpp
@@ -1,0 +1,32 @@
+#include <QCoreApplication>
+#include <QDebug>
+#include "NetworkClientProxy.h"
+
+int main(int argc, char **argv)
+{
+    QCoreApplication app(argc, argv);
+
+    NetworkClientProxy proxy("127.0.0.1", 1234);
+
+    try {
+        auto menu = proxy.getMenu();
+        qDebug() << "Menu size:" << (int)menu.size();
+        for (const auto &p : menu) {
+            qDebug() << p.id << QString::fromStdString(p.nombre) << p.precio;
+        }
+
+        // Crear pedido de prueba con el primer producto si existe
+        if (!menu.empty()) {
+            std::vector<ItemPedidoCrear> items;
+            ItemPedidoCrear it{menu.front().id, 1};
+            items.push_back(it);
+            proxy.finalizarPedido("ClienteTest", items, "nulo");
+            qDebug() << "Pedido enviado correctamente.";
+        }
+    } catch (const std::exception &ex) {
+        qWarning() << "Error:" << ex.what();
+        return 1;
+    }
+
+    return 0;
+}

--- a/client/src/test_network_proxy.cpp
+++ b/client/src/test_network_proxy.cpp
@@ -8,22 +8,27 @@ int main(int argc, char **argv)
 
     NetworkClientProxy proxy("127.0.0.1", 1234);
 
-    try {
+    try
+    {
         auto menu = proxy.getMenu();
         qDebug() << "Menu size:" << (int)menu.size();
-        for (const auto &p : menu) {
+        for (const auto &p : menu)
+        {
             qDebug() << p.id << QString::fromStdString(p.nombre) << p.precio;
         }
 
         // Crear pedido de prueba con el primer producto si existe
-        if (!menu.empty()) {
+        if (!menu.empty())
+        {
             std::vector<ItemPedidoCrear> items;
             ItemPedidoCrear it{menu.front().id, 1};
             items.push_back(it);
             proxy.finalizarPedido("ClienteTest", items, "nulo");
             qDebug() << "Pedido enviado correctamente.";
         }
-    } catch (const std::exception &ex) {
+    }
+    catch (const std::exception &ex)
+    {
         qWarning() << "Error:" << ex.what();
         return 1;
     }

--- a/common/include/api/Protocolo.h
+++ b/common/include/api/Protocolo.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <QString>
+
+namespace Protocolo
+{
+    // Puertos
+    static const int DEFAULT_PORT = 1234;
+
+    // Claves del JSON
+    static const QString KEY_CMD = "cmd";         // Qué quieres hacer
+    static const QString KEY_PAYLOAD = "payload"; // Datos (Argumentos)
+    static const QString KEY_STATUS = "status";   // OK / ERROR
+    static const QString KEY_MSG = "message";     // Mensaje de error o éxito
+    static const QString KEY_DATA = "data";       // Respuesta (ej: el menú)
+
+    // Comandos (Requests)
+    static const QString CMD_LOGIN = "LOGIN";
+    static const QString CMD_GET_MENU = "GET_MENU";
+    static const QString CMD_ADD_ORDER = "ADD_ORDER";
+
+    // Eventos (Push Notifications)
+    static const QString EVT_NEW_ORDER = "EVT_NEW_ORDER";
+    static const QString EVT_KITCHEN_UPDATE = "EVT_KITCHEN_UPDATE";
+}

--- a/docs/DiagramaRed.md
+++ b/docs/DiagramaRed.md
@@ -1,0 +1,138 @@
+# Diagrama de la capa de red (Network)
+
+Este documento explica de forma concisa cómo está diseñada la capa de red del proyecto: qué hace el servidor (`NetworkServer`), cómo despacha comandos (pattern Command), y cómo el cliente (`NetworkClientProxy`) actúa como proxy remoto del núcleo local. Está pensado para un desarrollador que no haya visto el proyecto antes.
+
+---
+
+## Componentes principales 🔧
+
+- **NetworkServer (server/)**
+
+  - Clase: `NetworkServer` (hereda de `QTcpServer`).
+  - Recibe conexiones TCP, mantiene una tabla de comandos y despacha peticiones entrantes a implementaciones de `IComandoServidor`.
+  - Archivos relevantes:
+    - `server/include/NetworkServer.h`
+    - `server/src/NetworkServer.cpp`
+
+- **IComandoServidor**
+
+  - Interfaz que define `virtual void ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload, SistemaPedidos &sistema) = 0;`.
+  - Cada comando concreto (por ejemplo `CmdGetMenu`, `CmdAddOrder`) implementa esta interfaz para manejar una petición específica.
+  - Archivos relevantes:
+    - `server/include/IComandoServidor.h`
+
+- **Comandos (pattern Command)**
+
+  - `CmdGetMenu` → lee menú desde `SistemaPedidos`, serializa y responde.
+  - `CmdAddOrder` → deserializa payload, llama a `SistemaPedidos::finalizarPedido(...)` y responde OK/ERROR.
+  - Archivos: `server/include/CmdGetMenu.h`, `server/src/CmdGetMenu.cpp`, `server/include/CmdAddOrder.h`, `server/src/CmdAddOrder.cpp`.
+
+- **NetworkClientProxy (client/)**
+
+  - Implementa la interfaz `ICoreSistema` que usa la UI. Internamente se comunica por TCP con `NetworkServer`.
+  - Realiza peticiones JSON framed (ver más abajo), espera la respuesta, y convierte JSON → DTOs (por ejemplo `InfoProducto`).
+  - Archivos: `client/src/NetworkClientProxy.h`, `client/src/NetworkClientProxy.cpp`.
+
+- **Helpers de protocolo (framing)**
+  - `NetworkProtocol::sendJson(...)` (en server y client): añade un prefijo de 4 bytes (big-endian) con la longitud del payload JSON y luego el payload en UTF-8.
+  - Esto evita los problemas de "sticky packets" del transporte TCP.
+
+---
+
+## Flujo de una petición (secuencia) 🔁
+
+1. La UI llama a un método del núcleo (ej. `getMenu()` o `finalizarPedido(...)`) que, cuando se usa el modo remoto, está implementado por `NetworkClientProxy`.
+2. `NetworkClientProxy` construye el objeto JSON de request: `{ "cmd": "CMD_NAME", "payload": { ... } }`.
+3. Envía el mensaje usando framing: 4 bytes BE con la longitud del JSON, seguido del JSON en UTF-8 (helper `NetworkProtocol::sendJson`).
+4. `NetworkServer` (por socket de cliente) recibe bytes, su `readyRead` acumula en un buffer por socket y procesa mensajes completos leyendo primero la longitud, luego el body JSON.
+5. `NetworkServer` parsea JSON, extrae la clave `cmd` y busca el comando en su mapa: `std::map<QString, std::shared_ptr<IComandoServidor>> comandos`.
+6. Si el comando existe, el servidor llama `comando->ejecutar(socket, payload, sistema)` e **inmediatamente** el comando puede enviar la respuesta por el mismo socket (también framed).
+7. `NetworkClientProxy` lee la respuesta framed, valida `status` y deserializa `data` a los DTOs que espera el UI.
+
+---
+
+## Formato de mensajes JSON 📑
+
+- **Request GET_MENU**
+
+  - Request:
+    ```json
+    { "cmd": "GET_MENU", "payload": {} }
+    ```
+  - Response (ejemplo):
+    ```json
+    {
+      "status": "OK",
+      "data": [ { "id": 1, "nombre": "Cafe", "precio": 5.5 }, ... ]
+    }
+    ```
+
+- **Request ADD_ORDER**
+  - Request payload esperado:
+    ```json
+    {
+      "cmd": "ADD_ORDER",
+      "payload": {
+        "cliente": "Nombre",
+        "id_descuento": "nulo",
+        "items": [ { "productoId": 1, "cantidad": 2 }, ... ]
+      }
+    }
+    ```
+  - Response: `{"status":"OK","message":"Pedido recibido"}` o `{"status":"ERROR","message":"..."}`
+
+Las claves del protocolo (ej: `KEY_CMD`, `KEY_PAYLOAD`, `KEY_STATUS`, `KEY_MSG`, `KEY_DATA`) están definidas en `common/include/api/Protocolo.h` para mantener coherencia cliente/servidor.
+
+---
+
+## Manejo de errores y robustez ⚠️
+
+- Framing: el prefijo de longitud evita problemas de mensajes concatenados o incompletos en TCP.
+- El servidor valida la estructura del JSON y responde con `status: "ERROR"` + `message` en caso de payload inválido.
+- El cliente (proxy) lanza excepciones (`std::runtime_error`) en casos como: no conectado, timeout esperando respuesta, JSON malformado o `status != "OK"`.
+- Recomendación futura: convertir las operaciones del proxy a asíncronas (signals/slots / promises) para no bloquear la UI y añadir reconexión automática.
+
+---
+
+## Cómo agregar un nuevo comando (pasos rápidos) ➕
+
+1. Crear la clase comando en `server/include/` y `server/src/` que herede `IComandoServidor` y implemente `ejecutar(...)`.
+2. Registrar el comando en el constructor de `NetworkServer` con la clave `Protocolo::CMD_...`.
+3. Añadir en `NetworkClientProxy` un método que construya el JSON `cmd`/`payload`, use `enviarRequestYEsperarRespuesta()` y mapee la respuesta a DTOs.
+
+---
+
+## Notas finales 💡
+
+- Arquitectura: el patrón Command desacopla el parsing / transporte (NetworkServer) de la lógica de negocio (comandos + SistemaPedidos), facil de probar y extender.
+- Las funciones de utilidad para framing están duplicadas en `server/include/NetworkProtocol.h` y `client/src/NetworkProtocol.h`. Tal vez para un mayor DRY, se moverá el helper a `common/` para compartir código.
+
+---
+
+## Diagrama de secuencia (Mermaid) 🧭
+
+El siguiente diagrama muestra una petición típica (ej: `GET_MENU`) y la respuesta, incluyendo el framing (prefijo de 4 bytes con la longitud):
+
+```mermaid
+sequenceDiagram
+  participant UI
+  participant Proxy as NetworkClientProxy
+  participant Socket as QTcpSocket
+  participant Server as NetworkServer
+  participant Cmd as CmdGetMenu/CmdAddOrder
+  participant Sistema as SistemaPedidos
+
+  UI->>Proxy: getMenu()
+  Proxy->>Socket: [4B len] + {"cmd":"GET_MENU","payload":{}}
+  Socket->>Server: TCP bytes
+  Server->>Server: acumula buffer, lee prefijo len, parsea JSON
+  Server->>Cmd: comando->ejecutar(socket, payload, sistema)
+  Cmd->>Sistema: sistema.getMenu() (o finalizarPedido(...))
+  Sistema-->>Cmd: DTOs / resultado
+  Cmd->>Server: sendJson(response) (framed)
+  Server->>Socket: TCP bytes (respuesta framed)
+  Socket->>Proxy: recibe framed response
+  Proxy->>UI: retorna vector<InfoProducto> o lanza error
+
+  Note over Socket,Server: Framing (4 byte BE length + JSON UTF-8)
+```

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -5,10 +5,19 @@ project(CafeteriaServer)
 # Paquetes necesarios
 find_package(Qt6 REQUIRED COMPONENTS Core Network Sql)
 
+# Activar AUTOMOC para procesar Q_OBJECT en headers
+set(CMAKE_AUTOMOC ON)
+
 # Buscar fuentes (ajustado a la nueva ruta)
 file(GLOB_RECURSE SERVER_SOURCES "src/*.cpp")
 
 add_executable(CafeteriaServer ${SERVER_SOURCES})
+
+# Algunos headers con Q_OBJECT deben ser procesados por AUTOMOC; asegurarse de
+# que estén registrados como fuentes para que CMake los tenga en cuenta.
+target_sources(CafeteriaServer PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/NetworkServer.h
+)
 
 # Includes y Librerías
 target_include_directories(CafeteriaServer

--- a/server/include/CmdAddOrder.h
+++ b/server/include/CmdAddOrder.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "IComandoServidor.h"
+
+class CmdAddOrder : public IComandoServidor
+{
+public:
+    CmdAddOrder() = default;
+    ~CmdAddOrder() override = default;
+
+    void ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload, SistemaPedidos &sistema) override;
+};

--- a/server/include/CmdGetMenu.h
+++ b/server/include/CmdGetMenu.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "IComandoServidor.h"
+
+class CmdGetMenu : public IComandoServidor
+{
+public:
+    CmdGetMenu() = default;
+    ~CmdGetMenu() override = default;
+
+    void ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload, SistemaPedidos &sistema) override;
+};

--- a/server/include/IComandoServidor.h
+++ b/server/include/IComandoServidor.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QJsonObject>
+
+class QTcpSocket;
+class SistemaPedidos;
+
+/**
+ * @brief Interfaz abstracta para comandos que procesa una petición del cliente.
+ *
+ * Cada comando implementará la lógica necesaria en el método ejecutar(), que
+ * recibe el socket del cliente (para responder), el payload parseado como JSON
+ * y una referencia al subsistema de pedidos para operar la lógica de negocio.
+ */
+class IComandoServidor
+{
+public:
+    virtual ~IComandoServidor() = default;
+
+    /**
+     * @brief Ejecuta el comando.
+     * @param clientSocket Puntero al socket del cliente (puede usarse para enviar la respuesta).
+     * @param payload Objeto JSON con los parámetros de la petición ya parseados.
+     * @param sistema Referencia al subsistema de negocio (facade) que maneja pedidos.
+     */
+    virtual void ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload, SistemaPedidos &sistema) = 0;
+};

--- a/server/include/NetworkProtocol.h
+++ b/server/include/NetworkProtocol.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QTcpSocket>
+#include <QJsonDocument>
+#include <QDataStream>
+
+namespace NetworkProtocol
+{
+
+    /**
+     * @brief Envía un objeto JSON en el formato "length-prefixed" (4 bytes big-endian
+     * que indican la longitud del payload seguido del payload JSON en UTF-8).
+     */
+    inline void sendJson(QTcpSocket *socket, const QJsonObject &obj)
+    {
+        if (!socket)
+            return;
+        QJsonDocument d(obj);
+        QByteArray payload = d.toJson(QJsonDocument::Compact);
+
+        QByteArray out;
+        QDataStream ds(&out, QIODevice::WriteOnly);
+        ds.setByteOrder(QDataStream::BigEndian);
+        ds << static_cast<quint32>(payload.size());
+        out.append(payload);
+
+        if (socket->isOpen())
+        {
+            socket->write(out);
+            socket->flush();
+        }
+    }
+
+} // namespace NetworkProtocol

--- a/server/include/NetworkServer.h
+++ b/server/include/NetworkServer.h
@@ -2,6 +2,7 @@
 
 #include <QTcpServer>
 #include <QSet>
+#include <QHash>
 #include <map>
 #include <memory>
 #include <QString>
@@ -39,5 +40,6 @@ private:
 
     std::map<QString, std::shared_ptr<IComandoServidor>> comandos;
     QSet<QTcpSocket *> clientes;
+    QHash<QTcpSocket *, QByteArray> recvBuffers;
     SistemaPedidos *sistema = nullptr; // no owned
 };

--- a/server/include/NetworkServer.h
+++ b/server/include/NetworkServer.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <QTcpServer>
+#include <QSet>
+#include <map>
+#include <memory>
+#include <QString>
+
+class IComandoServidor;
+class SistemaPedidos;
+
+/**
+ * @brief Servidor de red que escucha conexiones TCP y mantiene un registro de comandos.
+ *
+ * Además de escuchar, mantiene la lista de clientes conectados y despacha
+ * mensajes entrantes a las implementaciones de `IComandoServidor`.
+ */
+class NetworkServer : public QTcpServer
+{
+    Q_OBJECT
+
+public:
+    explicit NetworkServer(SistemaPedidos *sistema, QObject *parent = nullptr);
+    ~NetworkServer() override = default;
+
+    // Obtiene el comando registrado por nombre, o nullptr si no existe.
+    std::shared_ptr<IComandoServidor> getComando(const QString &cmd) const;
+
+protected:
+    // Sobrescribir para aceptar nuevas conexiones
+    void incomingConnection(qintptr socketDescriptor) override;
+
+private slots:
+    void onMensajeRecibido();
+    void onClienteDesconectado();
+
+private:
+    void enviarError(QTcpSocket *socket, const QString &mensaje);
+
+    std::map<QString, std::shared_ptr<IComandoServidor>> comandos;
+    QSet<QTcpSocket *> clientes;
+    SistemaPedidos *sistema = nullptr; // no owned
+};

--- a/server/src/CmdAddOrder.cpp
+++ b/server/src/CmdAddOrder.cpp
@@ -1,0 +1,123 @@
+#include "CmdAddOrder.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTcpSocket>
+#include <QString>
+
+#include "core/SistemaPedidos.h"
+#include "api/Protocolo.h"
+#include "api/ApiDTOs.h"
+
+void CmdAddOrder::ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload, SistemaPedidos &sistema)
+{
+    // Validación básica del payload
+    if (!payload.contains("cliente") || !payload.value("cliente").isString())
+    {
+        QJsonObject resp;
+        resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
+        resp.insert(Protocolo::KEY_MSG, QString("Campo 'cliente' faltante o inválido"));
+        QJsonDocument d(resp);
+        if (clientSocket && clientSocket->isOpen())
+            clientSocket->write(d.toJson(QJsonDocument::Compact));
+        return;
+    }
+
+    if (!payload.contains("items") || !payload.value("items").isArray())
+    {
+        QJsonObject resp;
+        resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
+        resp.insert(Protocolo::KEY_MSG, QString("Campo 'items' faltante o inválido"));
+        QJsonDocument d(resp);
+        if (clientSocket && clientSocket->isOpen())
+            clientSocket->write(d.toJson(QJsonDocument::Compact));
+        return;
+    }
+
+    QString clienteQ = payload.value("cliente").toString();
+    std::string cliente = clienteQ.toStdString();
+
+    std::string id_descuento = "nulo"; // default
+    if (payload.contains("id_descuento") && payload.value("id_descuento").isString())
+    {
+        id_descuento = payload.value("id_descuento").toString().toStdString();
+    }
+
+    QJsonArray itemsArray = payload.value("items").toArray();
+    if (itemsArray.isEmpty())
+    {
+        QJsonObject resp;
+        resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
+        resp.insert(Protocolo::KEY_MSG, QString("La lista 'items' está vacía"));
+        QJsonDocument d(resp);
+        if (clientSocket && clientSocket->isOpen())
+            clientSocket->write(d.toJson(QJsonDocument::Compact));
+        return;
+    }
+
+    std::vector<ItemPedidoCrear> items;
+    for (const QJsonValue &v : itemsArray)
+    {
+        if (!v.isObject())
+        {
+            QJsonObject resp;
+            resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
+            resp.insert(Protocolo::KEY_MSG, QString("Cada item debe ser un objeto con 'productoId' y 'cantidad'"));
+            QJsonDocument d(resp);
+            if (clientSocket && clientSocket->isOpen())
+                clientSocket->write(d.toJson(QJsonDocument::Compact));
+            return;
+        }
+        QJsonObject itm = v.toObject();
+
+        if (!itm.contains("productoId") || !itm.value("productoId").isDouble() || !itm.contains("cantidad") || !itm.value("cantidad").isDouble())
+        {
+            QJsonObject resp;
+            resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
+            resp.insert(Protocolo::KEY_MSG, QString("Items inválidos: se requiere 'productoId' y 'cantidad' numéricos"));
+            QJsonDocument d(resp);
+            if (clientSocket && clientSocket->isOpen())
+                clientSocket->write(d.toJson(QJsonDocument::Compact));
+            return;
+        }
+
+        ItemPedidoCrear item;
+        item.productoId = itm.value("productoId").toInt();
+        item.cantidad = itm.value("cantidad").toInt();
+        if (item.cantidad <= 0)
+        {
+            QJsonObject resp;
+            resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
+            resp.insert(Protocolo::KEY_MSG, QString("La 'cantidad' debe ser mayor que 0"));
+            QJsonDocument d(resp);
+            if (clientSocket && clientSocket->isOpen())
+                clientSocket->write(d.toJson(QJsonDocument::Compact));
+            return;
+        }
+
+        items.push_back(item);
+    }
+
+    // Invocar la API del sistema
+    try
+    {
+        sistema.finalizarPedido(cliente, items, id_descuento);
+
+        QJsonObject resp;
+        resp.insert(Protocolo::KEY_STATUS, QString("OK"));
+        resp.insert(Protocolo::KEY_MSG, QString("Pedido recibido y encolado"));
+        QJsonDocument d(resp);
+        if (clientSocket && clientSocket->isOpen())
+            clientSocket->write(d.toJson(QJsonDocument::Compact));
+    }
+    catch (const std::exception &ex)
+    {
+        QJsonObject resp;
+        resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
+        resp.insert(Protocolo::KEY_MSG, QString::fromStdString(ex.what()));
+        QJsonDocument d(resp);
+        if (clientSocket && clientSocket->isOpen())
+            clientSocket->write(d.toJson(QJsonDocument::Compact));
+    }
+}

--- a/server/src/CmdAddOrder.cpp
+++ b/server/src/CmdAddOrder.cpp
@@ -9,6 +9,7 @@
 #include "core/SistemaPedidos.h"
 #include "api/Protocolo.h"
 #include "api/ApiDTOs.h"
+#include "NetworkProtocol.h"
 
 void CmdAddOrder::ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload, SistemaPedidos &sistema)
 {
@@ -18,9 +19,7 @@ void CmdAddOrder::ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload,
         QJsonObject resp;
         resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
         resp.insert(Protocolo::KEY_MSG, QString("Campo 'cliente' faltante o inválido"));
-        QJsonDocument d(resp);
-        if (clientSocket && clientSocket->isOpen())
-            clientSocket->write(d.toJson(QJsonDocument::Compact));
+        NetworkProtocol::sendJson(clientSocket, resp);
         return;
     }
 
@@ -29,9 +28,7 @@ void CmdAddOrder::ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload,
         QJsonObject resp;
         resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
         resp.insert(Protocolo::KEY_MSG, QString("Campo 'items' faltante o inválido"));
-        QJsonDocument d(resp);
-        if (clientSocket && clientSocket->isOpen())
-            clientSocket->write(d.toJson(QJsonDocument::Compact));
+        NetworkProtocol::sendJson(clientSocket, resp);
         return;
     }
 
@@ -64,9 +61,7 @@ void CmdAddOrder::ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload,
             QJsonObject resp;
             resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
             resp.insert(Protocolo::KEY_MSG, QString("Cada item debe ser un objeto con 'productoId' y 'cantidad'"));
-            QJsonDocument d(resp);
-            if (clientSocket && clientSocket->isOpen())
-                clientSocket->write(d.toJson(QJsonDocument::Compact));
+            NetworkProtocol::sendJson(clientSocket, resp);
             return;
         }
         QJsonObject itm = v.toObject();
@@ -76,9 +71,7 @@ void CmdAddOrder::ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload,
             QJsonObject resp;
             resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
             resp.insert(Protocolo::KEY_MSG, QString("Items inválidos: se requiere 'productoId' y 'cantidad' numéricos"));
-            QJsonDocument d(resp);
-            if (clientSocket && clientSocket->isOpen())
-                clientSocket->write(d.toJson(QJsonDocument::Compact));
+            NetworkProtocol::sendJson(clientSocket, resp);
             return;
         }
 
@@ -107,17 +100,13 @@ void CmdAddOrder::ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload,
         QJsonObject resp;
         resp.insert(Protocolo::KEY_STATUS, QString("OK"));
         resp.insert(Protocolo::KEY_MSG, QString("Pedido recibido y encolado"));
-        QJsonDocument d(resp);
-        if (clientSocket && clientSocket->isOpen())
-            clientSocket->write(d.toJson(QJsonDocument::Compact));
+        NetworkProtocol::sendJson(clientSocket, resp);
     }
     catch (const std::exception &ex)
     {
         QJsonObject resp;
         resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
         resp.insert(Protocolo::KEY_MSG, QString::fromStdString(ex.what()));
-        QJsonDocument d(resp);
-        if (clientSocket && clientSocket->isOpen())
-            clientSocket->write(d.toJson(QJsonDocument::Compact));
+        NetworkProtocol::sendJson(clientSocket, resp);
     }
 }

--- a/server/src/CmdGetMenu.cpp
+++ b/server/src/CmdGetMenu.cpp
@@ -9,6 +9,7 @@
 #include "core/SistemaPedidos.h"
 #include "api/Protocolo.h"
 #include "api/ApiDTOs.h"
+#include "NetworkProtocol.h"
 
 void CmdGetMenu::ejecutar(QTcpSocket *clientSocket, const QJsonObject & /*payload*/, SistemaPedidos &sistema)
 {
@@ -29,12 +30,5 @@ void CmdGetMenu::ejecutar(QTcpSocket *clientSocket, const QJsonObject & /*payloa
     response.insert(Protocolo::KEY_STATUS, QString("OK"));
     response.insert(Protocolo::KEY_DATA, arr);
 
-    QJsonDocument doc(response);
-    QByteArray bytes = doc.toJson(QJsonDocument::Compact);
-
-    if (clientSocket && clientSocket->isOpen())
-    {
-        clientSocket->write(bytes);
-        clientSocket->flush();
-    }
+    NetworkProtocol::sendJson(clientSocket, response);
 }

--- a/server/src/CmdGetMenu.cpp
+++ b/server/src/CmdGetMenu.cpp
@@ -1,0 +1,40 @@
+#include "CmdGetMenu.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTcpSocket>
+#include <QString>
+
+#include "core/SistemaPedidos.h"
+#include "api/Protocolo.h"
+#include "api/ApiDTOs.h"
+
+void CmdGetMenu::ejecutar(QTcpSocket *clientSocket, const QJsonObject & /*payload*/, SistemaPedidos &sistema)
+{
+    // Obtener el menú desde el subsistema
+    std::vector<InfoProducto> menu = sistema.getMenu();
+
+    QJsonArray arr;
+    for (const auto &p : menu)
+    {
+        QJsonObject obj;
+        obj.insert("id", static_cast<int>(p.id));
+        obj.insert("nombre", QString::fromStdString(p.nombre));
+        obj.insert("precio", p.precio);
+        arr.append(obj);
+    }
+
+    QJsonObject response;
+    response.insert(Protocolo::KEY_STATUS, QString("OK"));
+    response.insert(Protocolo::KEY_DATA, arr);
+
+    QJsonDocument doc(response);
+    QByteArray bytes = doc.toJson(QJsonDocument::Compact);
+
+    if (clientSocket && clientSocket->isOpen())
+    {
+        clientSocket->write(bytes);
+        clientSocket->flush();
+    }
+}

--- a/server/src/NetworkServer.cpp
+++ b/server/src/NetworkServer.cpp
@@ -1,0 +1,121 @@
+#include "NetworkServer.h"
+
+#include "CmdGetMenu.h"
+#include "CmdAddOrder.h"
+#include "api/Protocolo.h"
+
+#include <QHostAddress>
+#include <iostream>
+#include <QTcpSocket>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include "core/SistemaPedidos.h"
+
+NetworkServer::NetworkServer(SistemaPedidos *sistemaPtr, QObject *parent)
+    : QTcpServer(parent), sistema(sistemaPtr)
+{
+    // Iniciar escucha en todas las interfaces en el puerto por defecto
+    if (!this->listen(QHostAddress::Any, Protocolo::DEFAULT_PORT))
+    {
+        std::cerr << "NetworkServer: No se pudo bindear al puerto " << Protocolo::DEFAULT_PORT << std::endl;
+    }
+    else
+    {
+        std::cout << "NetworkServer: escuchando en puerto " << Protocolo::DEFAULT_PORT << std::endl;
+    }
+
+    // Registrar comandos disponibles
+    comandos.insert({Protocolo::CMD_GET_MENU, std::make_shared<CmdGetMenu>()});
+    comandos.insert({Protocolo::CMD_ADD_ORDER, std::make_shared<CmdAddOrder>()});
+}
+
+std::shared_ptr<IComandoServidor> NetworkServer::getComando(const QString &cmd) const
+{
+    auto it = comandos.find(cmd);
+    if (it == comandos.end())
+        return nullptr;
+    return it->second;
+}
+
+void NetworkServer::incomingConnection(qintptr socketDescriptor)
+{
+    QTcpSocket *socket = new QTcpSocket(this);
+    if (!socket->setSocketDescriptor(socketDescriptor))
+    {
+        std::cerr << "NetworkServer: fallo al aceptar descriptor de socket" << std::endl;
+        socket->deleteLater();
+        return;
+    }
+
+    clientes.insert(socket);
+
+    connect(socket, &QTcpSocket::readyRead, this, &NetworkServer::onMensajeRecibido);
+    connect(socket, &QTcpSocket::disconnected, this, &NetworkServer::onClienteDesconectado);
+
+    std::cout << "NetworkServer: cliente conectado" << std::endl;
+}
+
+void NetworkServer::onClienteDesconectado()
+{
+    QTcpSocket *socket = qobject_cast<QTcpSocket *>(sender());
+    if (!socket)
+        return;
+    clientes.remove(socket);
+    socket->deleteLater();
+    std::cout << "NetworkServer: cliente desconectado" << std::endl;
+}
+
+void NetworkServer::enviarError(QTcpSocket *socket, const QString &mensaje)
+{
+    QJsonObject resp;
+    resp.insert(Protocolo::KEY_STATUS, QString("ERROR"));
+    resp.insert(Protocolo::KEY_MSG, mensaje);
+    QJsonDocument d(resp);
+    if (socket && socket->isOpen())
+        socket->write(d.toJson(QJsonDocument::Compact));
+}
+
+void NetworkServer::onMensajeRecibido()
+{
+    QTcpSocket *socket = qobject_cast<QTcpSocket *>(sender());
+    if (!socket)
+        return;
+
+    QByteArray raw = socket->readAll();
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(raw, &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject())
+    {
+        enviarError(socket, QString("JSON malformado: %1").arg(err.errorString()));
+        return;
+    }
+
+    QJsonObject obj = doc.object();
+    if (!obj.contains(Protocolo::KEY_CMD) || !obj.value(Protocolo::KEY_CMD).isString())
+    {
+        enviarError(socket, QString("Falta campo 'cmd' o es inválido"));
+        return;
+    }
+
+    QString cmd = obj.value(Protocolo::KEY_CMD).toString();
+    QJsonObject payload = obj.contains(Protocolo::KEY_PAYLOAD) && obj.value(Protocolo::KEY_PAYLOAD).isObject()
+                              ? obj.value(Protocolo::KEY_PAYLOAD).toObject()
+                              : QJsonObject();
+
+    auto comando = getComando(cmd);
+    if (!comando)
+    {
+        enviarError(socket, QString("Comando desconocido: %1").arg(cmd));
+        return;
+    }
+
+    if (!sistema)
+    {
+        enviarError(socket, QString("Servidor no tiene acceso al subsistema de negocio"));
+        return;
+    }
+
+    // Despachar al comando
+    comando->ejecutar(socket, payload, *sistema);
+}

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -4,12 +4,17 @@
 #include "repositories/ProductRepository.h"
 #include "repositories/PedidoRepository.h"
 #include "NetworkServer.h"
+#include "db/DatabaseManager.h"
 
 int main(int argc, char *argv[])
 {
     QCoreApplication app(argc, argv);
 
-    // Crear repositorios y cargar datos
+    // Inicializar la base de datos en memoria y poblarla con seed.sql (solo para pruebas)
+    DatabaseManager::instance().inicializarTablas();
+    DatabaseManager::instance().seedData();
+
+    // Crear repositorios y cargar datos desde la DB
     auto productRepository = std::make_shared<ProductRepository>();
     productRepository->loadFromDB();
 

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -3,6 +3,7 @@
 #include "core/SistemaPedidos.h"
 #include "repositories/ProductRepository.h"
 #include "repositories/PedidoRepository.h"
+#include "NetworkServer.h"
 
 int main(int argc, char *argv[])
 {
@@ -16,6 +17,9 @@ int main(int argc, char *argv[])
 
     // Inyectar repositorios en SistemaPedidos
     SistemaPedidos sistema(productRepository, pedidoRepository);
+
+    // Crear y arrancar servidor de red (usa el subsistema de pedidos)
+    NetworkServer servidor(&sistema);
 
     // Mantener la app viva
     return app.exec();


### PR DESCRIPTION
## Resumen de cambios principales 
- Se añadió un protocolo JSON y framing length‑prefixed (4 bytes big‑endian) para mensajes TCP.  
- Se creó la interfaz de comando del servidor: **`IComandoServidor`**.  
- Implementado en el servidor:
  - **`CmdGetMenu`** (obtiene menú desde `SistemaPedidos`)  
  - **`CmdAddOrder`** (recibe pedido, valida payload y llama `finalizarPedido`)  
  - **`NetworkServer`**: escucha, acepta clientes, parsea framing, despacha comandos.  
- Implementado en el cliente:
  - **`NetworkClientProxy`** que implementa `ICoreSistema` y llama al servidor (métodos sincrónicos: `getMenu()`, `finalizarPedido(...)`).  
  - Helpers de framing en NetworkProtocol.h (analogía en NetworkProtocol.h).  
- Añadidas pruebas mínimas:
  - test_get_menu_client.py (Python) — prueba GET_MENU framed.
  - `client/TestNetworkProxy` (Ejecutable) — prueba GET_MENU + ADD_ORDER usando `NetworkClientProxy`.
- Documentación: DiagramaRed.md con explicaciones y diagrama Mermaid del flujo.

---

## Impacto en cliente y servidor 

Cliente:
- Nuevo componente `NetworkClientProxy` que puede reemplazar al núcleo local (implementa `ICoreSistema`).
- El proxy es sincrónico por ahora (bloquea esperando respuesta); la UI no se modificó todavía.
- Se agregó test ejecutable `TestNetworkProxy` para validar el flujo cliente→servidor.

Servidor:
- `NetworkServer` recibe conexiones, hace framing-aware reads, valida JSON y despacha a comandos.
- Nuevos comandos hacen uso de `SistemaPedidos` sin cambiar su lógica interna.
- Se añadió carga de DB en memoria desde seed.sql (para pruebas).

Archivos clave (no exhaustivo):
- server: `NetworkServer.{h,cpp}`, `IComandoServidor.h`, `CmdGetMenu.*`, `CmdAddOrder.*`, `NetworkProtocol.h`
- client: `NetworkClientProxy.{h,cpp}`, `NetworkProtocol.h`, `test_network_proxy.cpp`
- common: `Protocolo.h`, ApiDTOs.h
- docs: DiagramaRed.md

---

## Cómo probar (pasos reproducibles) 

1) Configurar / compilar:
```bash
# desde la raíz del repo
cmake -S . -B build
cmake --build build --target CafeteriaServer -- -j 2
# (opcional) compilar test del proxy o cliente
cmake --build build --target TestNetworkProxy -- -j 2
cmake --build build --target CafeteriaClient -- -j 2  # si se quiere probar la UI
```

2) Levantar el servidor (en memoria con seed de prueba):
```bash
# en primer terminal
./build/server/CafeteriaServer
# o en background
./build/server/CafeteriaServer &
```
- Al arrancar, en modo test la DB en memoria se inicializa con seed.sql (3 productos de ejemplo).

3) Probar GET_MENU:
- Opción A (script Python):
```bash
python3 archived/test_get_menu_client.py
```
- Opción B (ejecutable de prueba):
```bash
./build/client/TestNetworkProxy
# imprimirá el menú y enviará un ADD_ORDER de prueba
```
- Resultado esperado: `status: "OK"` y `data` con la lista de productos (JSON framed).

4) Probar ADD_ORDER:
- Usar `TestNetworkProxy` (envía un pedido con el primer producto). Comprueba en los logs del servidor la acción y la respuesta `OK`/`ERROR`.

Nota: si ejecuta el cliente GUI (CafeteriaClient) más adelante, se podrá inyectar `NetworkClientProxy` en lugar del núcleo local para probar la UI contra el servidor.

---

## Riesgos conocidos y limitaciones ⚠️
- El `NetworkClientProxy` es sincrónico y puede bloquear la UI si se usa directamente desde el hilo de UI. Recomendable: hacerlo asíncrono (signals/slots o promesas).
- El helper de framing está duplicado (cliente y servidor). Podría factorizarse a common para evitar duplicación.
- Actualmente la carga de seed.sql se hace automáticamente en main.cpp (solo para pruebas). Debe hacerse opcional (p. ej. por variable de entorno o flag) para entornos no‑dev.
- No hay autenticación/autoridad todavía (falta `CmdLogin` y manejo de sesiones/roles).
- No se ha implementado cifrado ni TLS del canal TCP (si es necesario para producción).
- Algunas validaciones de payload devuelven `ERROR` con mensaje, pero no hay codificación de errores estandarizada más allá del texto.

---

## Próximos pasos recomendados ✅
- Implementar comando de autenticación: **CmdLogin** + flujo de sesión en `NetworkClientProxy`.  
- Hacer el `NetworkClientProxy` asíncrono (no bloquear UI) y añadir reconexión automática.  
- Mover helpers de `NetworkProtocol` a common para reutilización y evitar duplicados.  
- Añadir tests automáticos de integración (start server headless + tests que envíen GET_MENU/ADD_ORDER y verifiquen efectos).  
- Controlar la carga de seed.sql mediante variable de entorno o flag `--seed` para evitar cargar datos en entornos no‑controlados.  
- Añadir tests unitarios para `NetworkServer` (mocks de sockets) y tests de estrés / concurrency.

Closes #21