### PR TITLE
WBS-3: añadir eventos en tiempo real (EVT_NEW_ORDER), GET_ORDERS, matching de respuestas y tests

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -33,3 +33,11 @@ target_link_libraries(TestNetworkProxy PRIVATE Qt${QT_VERSION_MAJOR}::Network Qt
 target_link_libraries(CafeteriaClient PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Network)
 
 target_link_libraries(CafeteriaClient PRIVATE CafeteriaCommon)
+
+# Target helper para ejecutar el cliente con LD_PRELOAD para evitar conflicto con snap
+add_custom_target(run-client
+    COMMAND ${CMAKE_COMMAND} -E echo "Ejecutando CafeteriaClient (LD_PRELOAD workaround)..."
+    COMMAND ${CMAKE_COMMAND} -E env LD_PRELOAD=/lib/x86_64-linux-gnu/libpthread.so.0 ${CMAKE_BINARY_DIR}/client/CafeteriaClient
+    DEPENDS CafeteriaClient
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)

--- a/client/src/NetworkClientProxy.cpp
+++ b/client/src/NetworkClientProxy.cpp
@@ -31,15 +31,15 @@ NetworkClientProxy::NetworkClientProxy(const QString &host_, quint16 port_)
     }
 
     // Conectar la señal errorOccurred del socket para retransmitirla hacia el UI
-    connect(socket, &QTcpSocket::errorOccurred, this, [this](QAbstractSocket::SocketError socketError) {
+    connect(socket, &QTcpSocket::errorOccurred, this, [this](QAbstractSocket::SocketError socketError)
+            {
         Q_UNUSED(socketError);
         if (socket)
         {
             QString mensaje = socket->errorString();
             qWarning() << "NetworkClientProxy: socket error:" << mensaje;
             emit errorOcurrido(mensaje);
-        }
-    });
+        } });
 }
 
 NetworkClientProxy::~NetworkClientProxy()
@@ -74,15 +74,15 @@ void NetworkClientProxy::conectar(const QString &host_, quint16 port_)
     }
 
     // Conectar la señal errorOccurred del socket para retransmitirla hacia el UI
-    connect(socket, &QTcpSocket::errorOccurred, this, [this](QAbstractSocket::SocketError socketError) {
+    connect(socket, &QTcpSocket::errorOccurred, this, [this](QAbstractSocket::SocketError socketError)
+            {
         Q_UNUSED(socketError);
         if (socket)
         {
             QString mensaje = socket->errorString();
             qWarning() << "NetworkClientProxy: socket error:" << mensaje;
             emit errorOcurrido(mensaje);
-        }
-    });
+        } });
 }
 
 void NetworkClientProxy::registrarObservador(std::shared_ptr<IObservadorCore> obs)

--- a/client/src/NetworkClientProxy.h
+++ b/client/src/NetworkClientProxy.h
@@ -57,4 +57,8 @@ private:
 
     // Enviar una petición y esperar la respuesta (bloqueante)
     QJsonObject enviarRequestYEsperarRespuesta(const QString &cmd, const QJsonObject &payload, int timeoutMs = 3000);
+
+public:
+    // Test helper: inyectar bytes crudos como si vinieran del socket (para tests sin red)
+    void feedRawDataForTest(const QByteArray &data);
 };

--- a/client/src/NetworkClientProxy.h
+++ b/client/src/NetworkClientProxy.h
@@ -37,6 +37,13 @@ signals:
     // Emitido cuando llega una respuesta JSON completa (a cualquier petición)
     void respuestaRecibida(const QJsonObject &obj);
 
+    // Señal para informar errores de conexión u otros errores de socket
+    void errorOcurrido(const QString &mensaje);
+
+public slots:
+    // Intenta conectar al host/puerto provistos y emite errorOcurrido en caso de fallo
+    void conectar(const QString &host_, quint16 port_);
+
 private slots:
     // Slot asíncrono que procesa datos entrantes del socket y extrae mensajes framed
     void onDatosRecibidos();

--- a/client/src/NetworkClientProxy.h
+++ b/client/src/NetworkClientProxy.h
@@ -52,6 +52,9 @@ private:
     // Cola de respuestas JSON recibidas
     QQueue<QJsonObject> colaRespuestas;
 
+    // Observador (UI) que será notificado de eventos push (ej: EVT_NEW_ORDER)
+    std::shared_ptr<IObservadorCore> observador = nullptr;
+
     // Enviar una petición y esperar la respuesta (bloqueante)
     QJsonObject enviarRequestYEsperarRespuesta(const QString &cmd, const QJsonObject &payload, int timeoutMs = 3000);
 };

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -178,8 +178,8 @@ int main(int argc, char *argv[])
             background-color: #0fce4d;
         }
     )");
-    // Crear NetworkClientProxy, conectar señales y pasar al MainWindow
-    NetworkClientProxy *proxy = new NetworkClientProxy();
+    // Crear NetworkClientProxy sin auto-conectar (evitar doble intento)
+    NetworkClientProxy *proxy = new NetworkClientProxy(QStringLiteral(""), 0);
 
     QObject::connect(proxy, &NetworkClientProxy::errorOcurrido, [](const QString &msg)
                      { QMessageBox::critical(nullptr, "Error de Conexión", msg); });

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -1,7 +1,10 @@
 #include "mainwindow.h"
+#include "NetworkClientProxy.h"
+#include "../../common/include/api/Protocolo.h"
 
 #include <QApplication>
 #include <QStyleFactory>
+#include <QMessageBox>
 
 int main(int argc, char *argv[])
 {
@@ -175,7 +178,16 @@ int main(int argc, char *argv[])
             background-color: #0fce4d;
         }
     )");
-    MainWindow w;
+    // Crear NetworkClientProxy, conectar señales y pasar al MainWindow
+    NetworkClientProxy *proxy = new NetworkClientProxy();
+
+    QObject::connect(proxy, &NetworkClientProxy::errorOcurrido, [](const QString &msg)
+                     { QMessageBox::critical(nullptr, "Error de Conexión", msg); });
+
+    // Intentar conectar (emitirá errorOcurrido si falla)
+    proxy->conectar(QStringLiteral("127.0.0.1"), Protocolo::DEFAULT_PORT);
+
+    MainWindow w(proxy);
     w.show();
     return a.exec();
 }

--- a/client/src/mainwindow.h
+++ b/client/src/mainwindow.h
@@ -11,6 +11,9 @@
 // Clases de implementación del core
 #include "CoreQtAdapter.h" // 'Traductor' de observadores C++ a señales Qt
 
+#include <QListWidgetItem>
+#include <QJsonObject>
+
 QT_BEGIN_NAMESPACE
 namespace Ui
 {
@@ -91,6 +94,9 @@ private slots:
      */
     void on_btnQuitarItem_clicked();
 
+    // Slot: agregar producto al pedido al hacer clic en la lista de productos
+    void agregarProductoAlPedido(QListWidgetItem *item);
+
     // Slots "Vista Cocina"
     /**
      * @brief Se activa cuando el cocinero presiona "Procesar Siguiente Pedido".
@@ -116,5 +122,9 @@ private slots:
     void onNuevosPedidosEnCola() override;
     void onPedidoTerminado(int id_pedido) override;
     void onError(const std::string &mensaje) override;
+
+private:
+    // Total acumulado en la orden actual (para actualizar label y habilitar botón)
+    double m_totalActual = 0.0;
 };
 #endif // MainWindow_H

--- a/client/src/mainwindow.h
+++ b/client/src/mainwindow.h
@@ -84,6 +84,9 @@ private slots:
      */
     void on_btnFinalizarPedido_clicked();
 
+    // Slot para enviar el pedido agrupado al servidor
+    void finalizarPedido();
+
     /**
      * @brief on_btnAnadirItem_clicked Slot llamado al hacer clic en el botón "Añadir Ítem".
      */

--- a/common/include/api/Protocolo.h
+++ b/common/include/api/Protocolo.h
@@ -17,6 +17,8 @@ namespace Protocolo
     static const QString CMD_LOGIN = "LOGIN";
     static const QString CMD_GET_MENU = "GET_MENU";
     static const QString CMD_ADD_ORDER = "ADD_ORDER";
+    // Nuevo comando para obtener pedidos activos (vista Cocina)
+    static const QString CMD_GET_ORDERS = "GET_ORDERS";
 
     // Eventos (Push Notifications)
     static const QString EVT_NEW_ORDER = "EVT_NEW_ORDER";

--- a/docs/WBS-3-Implementacion.md
+++ b/docs/WBS-3-Implementacion.md
@@ -1,0 +1,103 @@
+# WBS‑3: Implementación - Eventos en Tiempo Real
+
+## Resumen ejecutivo
+
+Se implementó soporte de notificaciones en tiempo real en el sistema cliente‑servidor. Cuando un cliente finaliza un pedido, el servidor difunde `EVT_NEW_ORDER` a todos los clientes conectados; las UIs (vista Cocina) reciben el evento y solicitan `GET_ORDERS` para actualizar la lista de pedidos activos. Adicionalmente se añadieron mejoras en el cliente para distinguir eventos push de respuestas a peticiones y se añadieron tests de integración para validar el comportamiento multi‑cliente.
+
+---
+
+## Cambios principales y archivos clave
+
+### Server
+
+- `server/src/commands/CmdGetOrders.cpp` (nuevo)
+- `server/include/commands/CmdGetOrders.h` (nuevo)
+- `server/src/repositories/ClienteRepository.cpp` (nuevo)
+- `server/include/repositories/ClienteRepository.h` (nuevo)
+- `server/src/core/SistemaPedidos.cpp` (modificado: integración ClienteRepository, correcciones de observadores)
+- `server/src/NetworkServer.cpp` (modificado: registro de comandos, método difundirEvento, logging)
+
+### Client
+
+- `client/src/NetworkClientProxy.cpp` (modificado: manejo de eventos, matching de respuestas, reintento en getPedidosActivos, helper de test)
+- `client/src/NetworkClientProxy.h` (actualizado)
+- `client/src/mainwindow.cpp` (modificado: validación de payload antes de repoblar menú)
+- `client/CMakeLists.txt` (añadido target `run-client`)
+- `run_client.sh` (nuevo: workaround LD_PRELOAD para Snap/libpthread)
+
+### Tests
+
+- `tests/test_network_proxy_async.cpp` (QtTest)
+- `tests/test_network_proxy_orders.cpp` (QtTest)
+- `tests/test_network_proxy_broadcast_integration.cpp` (QtTest)
+- `tests/test_network_proxy_endtoend.cpp` (QtTest)
+- `tests/test_network_broadcast.cpp` (gtest)
+- `tests/CMakeLists.txt` (modificado: separar Qt tests y google test targets, añadir fuentes server cuando aplica)
+
+### Docs
+
+- `docs/WBS-3-Implementacion.md` (este archivo)
+- `docs/DiagramaRed.md` (actualizado con sección "Eventos Push")
+
+---
+
+## Características añadidas
+
+- Difusión de eventos `EVT_NEW_ORDER` por parte del servidor.
+- Comando `GET_ORDERS` para obtener pedidos activos.
+- Cliente detecta eventos push y notifica la UI; la UI luego solicita `GET_ORDERS` para refrescar.
+- Matching de respuestas en el proxy (evita consumir respuestas no relacionadas con la petición actual).
+- Tests de integración para validar broadcast multi‑cliente.
+
+---
+
+## Bugs y problemas resueltos
+
+- Race en el primer `finalizarPedido` que provocaba timeout: solucionado con matching de respuestas, debounce en eventos y retry en `getPedidosActivos()`.
+- Reemplazo del menú por payloads de pedidos (precio S/0.00): solucionado validando el formato de `KEY_DATA` antes de repoblar menú.
+- Tests flakey por duplicidad de mains y fuentes faltantes: reorganizados targets de tests en CMake y añadidos archivos faltantes a test targets.
+
+---
+
+## Comandos para compilar y validar
+
+- Compilar todo:
+
+```bash
+cmake -S . -B build
+cmake --build build -- -j$(nproc)
+```
+
+- Ejecutar todos los tests:
+
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+- Ejecutar tests individuales relevantes:
+
+```bash
+./build/tests/network_proxy_broadcast_integration -vs
+./build/tests/network_proxy_endtoend -vs
+./build/tests/network_proxy_orders -vs
+```
+
+- Ejecutar servidor y clientes manualmente:
+
+```bash
+./build/server/CafeteriaServer
+./run_client.sh ./build/client/CafeteriaClient
+# abrir dos instancias del cliente, finalizar pedido en cliente A y observar que cliente B reciba EVT_NEW_ORDER y haga GET_ORDERS
+```
+
+---
+
+## Notas finales y recomendaciones
+
+- Se recomienda planear un WBS‑4 para introducir `request_id` en requests/responses para eliminar las heurísticas de matching por contenido.
+- Convertir operaciones síncronas del proxy a asíncronas para evitar bloquear la UI.
+- Mejorar telemetría y logging (trace ids) para depuración en producción.
+
+---
+
+_Archivo generado automáticamente como parte del cierre de WBS-3._

--- a/run_client.sh
+++ b/run_client.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Wrapper para ejecutar CafeteriaClient evitando conflicto con librerías de snap (libpthread)
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLIENT_BIN="$ROOT_DIR/build/client/CafeteriaClient"
+if [ ! -x "$CLIENT_BIN" ]; then
+  echo "ERROR: no se encontró el binario: $CLIENT_BIN" >&2
+  echo "Compila con: cmake --build build --target CafeteriaClient" >&2
+  exit 1
+fi
+# Forzar uso de la pthread del sistema antes que la de snap
+export LD_PRELOAD="/lib/x86_64-linux-gnu/libpthread.so.0"
+# Optionally unset LD_LIBRARY_PATH if set by the environment (QtCreator snap)
+unset LD_LIBRARY_PATH || true
+exec "$CLIENT_BIN" "$@"

--- a/server/include/NetworkProtocol.h
+++ b/server/include/NetworkProtocol.h
@@ -26,8 +26,11 @@ namespace NetworkProtocol
 
         if (socket->isOpen())
         {
+            qDebug() << "NetworkProtocol::sendJson - writing" << out.size() << "bytes to" << socket;
             socket->write(out);
             socket->flush();
+            // Asegurar que bytes lleguen al stack de escritura
+            socket->waitForBytesWritten(200);
         }
     }
 

--- a/server/include/NetworkServer.h
+++ b/server/include/NetworkServer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <QTcpServer>
-#include <QSet>
+#include <QList>
 #include <QHash>
 #include <map>
 #include <memory>
@@ -38,8 +38,18 @@ private slots:
 private:
     void enviarError(QTcpSocket *socket, const QString &mensaje);
 
+    // Mantener lista de clientes conectados para broadcast y gestión
+    QList<QTcpSocket *> clientesConectados;
+
+    // Recepción por socket (buffers) y mapa de comandos
     std::map<QString, std::shared_ptr<IComandoServidor>> comandos;
-    QSet<QTcpSocket *> clientes;
     QHash<QTcpSocket *, QByteArray> recvBuffers;
     SistemaPedidos *sistema = nullptr; // no owned
+
+    // Remover cliente (llamado en slot disconnected)
+    void removerCliente(QTcpSocket *socket);
+
+public:
+    // Accesor usado en tests TDD
+    int getClientesConectadosCount() const { return clientesConectados.count(); }
 };

--- a/server/include/NetworkServer.h
+++ b/server/include/NetworkServer.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <QString>
+#include "../../common/include/api/IObservadorCore.h"
 
 class IComandoServidor;
 class SistemaPedidos;
@@ -16,7 +17,7 @@ class SistemaPedidos;
  * Además de escuchar, mantiene la lista de clientes conectados y despacha
  * mensajes entrantes a las implementaciones de `IComandoServidor`.
  */
-class NetworkServer : public QTcpServer
+class NetworkServer : public QTcpServer, public IObservadorCore
 {
     Q_OBJECT
 
@@ -48,6 +49,15 @@ private:
 
     // Remover cliente (llamado en slot disconnected)
     void removerCliente(QTcpSocket *socket);
+
+public:
+    // Difundir un evento JSON (formato string con JSON) a todos los clientes conectados
+    void difundirEvento(const std::string &jsonEvento);
+
+    // IObservadorCore methods
+    void onNuevosPedidosEnCola() override;
+    void onPedidoTerminado(int id_pedido) override {}
+    void onError(const std::string &mensaje) override {}
 
 public:
     // Accesor usado en tests TDD

--- a/server/include/core/SistemaPedidos.h
+++ b/server/include/core/SistemaPedidos.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include "repositories/ProductRepository.h"
 #include "repositories/PedidoRepository.h"
+#include "repositories/ClienteRepository.h"
 
 class Persona;
 class Pedido;
@@ -49,9 +50,16 @@ private:
     std::atomic<int> proximoIdPersona{1};
 
 public:
-    SistemaPedidos(std::shared_ptr<ProductRepository> prodRepo, std::shared_ptr<PedidoRepository> orderRepo);
+    SistemaPedidos(std::shared_ptr<ProductRepository> prodRepo, std::shared_ptr<PedidoRepository> orderRepo, std::shared_ptr<repos::ClienteRepository> clienteRepo);
     ~SistemaPedidos();
 
+private:
+    /**
+     * @brief Repositorio de clientes (acceso a la tabla customers).
+     */
+    std::shared_ptr<repos::ClienteRepository> clienteRepository;
+
+public:
     // Delegación y gestión
     void mostrarMenu() const;
     /**

--- a/server/include/repositories/ClienteRepository.h
+++ b/server/include/repositories/ClienteRepository.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+class Cliente;
+
+namespace repos
+{
+
+    class ClienteRepository
+    {
+    public:
+        ClienteRepository();
+        ~ClienteRepository();
+
+        // Busca un cliente por nombre en la base de datos. Devuelve nullptr si no existe
+        std::shared_ptr<Cliente> findByName(const std::string &name);
+
+        // Crea un cliente a partir de los datos y lo persiste en DB
+        std::shared_ptr<Cliente> create(const std::string &name, const std::string &taxId);
+    };
+
+} // namespace repos

--- a/server/src/CmdAddOrder.cpp
+++ b/server/src/CmdAddOrder.cpp
@@ -1,4 +1,4 @@
-#include "CmdAddOrder.h"
+#include "commands/CmdAddOrder.h"
 
 #include <QJsonArray>
 #include <QJsonDocument>

--- a/server/src/CmdGetMenu.cpp
+++ b/server/src/CmdGetMenu.cpp
@@ -1,4 +1,4 @@
-#include "CmdGetMenu.h"
+#include "commands/CmdGetMenu.h"
 
 #include <QJsonArray>
 #include <QJsonDocument>

--- a/server/src/NetworkServer.cpp
+++ b/server/src/NetworkServer.cpp
@@ -2,6 +2,7 @@
 
 #include "commands/CmdGetMenu.h"
 #include "commands/CmdAddOrder.h"
+#include "commands/CmdGetOrders.h"
 #include "api/Protocolo.h"
 
 #include <QHostAddress>
@@ -30,6 +31,7 @@ NetworkServer::NetworkServer(SistemaPedidos *sistemaPtr, QObject *parent)
     // Registrar comandos disponibles
     comandos.insert({Protocolo::CMD_GET_MENU, std::make_shared<CmdGetMenu>()});
     comandos.insert({Protocolo::CMD_ADD_ORDER, std::make_shared<CmdAddOrder>()});
+    comandos.insert({Protocolo::CMD_GET_ORDERS, std::make_shared<CmdGetOrders>()});
 }
 
 std::shared_ptr<IComandoServidor> NetworkServer::getComando(const QString &cmd) const
@@ -123,6 +125,7 @@ void NetworkServer::difundirEvento(const std::string &jsonEvento)
     QJsonObject obj = doc.object();
 
     qDebug() << "NetworkServer::difundirEvento - enviando evento a" << clientesConectados.count() << "clientes";
+    qDebug() << "NetworkServer::difundirEvento - payload:" << QJsonDocument(obj).toJson(QJsonDocument::Compact);
     for (QTcpSocket *sock : clientesConectados)
     {
         if (!sock)

--- a/server/src/commands/CmdGetOrders.cpp
+++ b/server/src/commands/CmdGetOrders.cpp
@@ -1,0 +1,46 @@
+#include "CmdGetOrders.h"
+#include "api/Protocolo.h"
+#include "NetworkProtocol.h"
+#include "core/SistemaPedidos.h"
+#include "api/ApiDTOs.h"
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <QDebug>
+
+void CmdGetOrders::ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload, SistemaPedidos &sistema)
+{
+    Q_UNUSED(payload);
+    qDebug() << "CmdGetOrders: obteniendo pedidos activos desde el sistema";
+
+    std::vector<InfoPedido> pedidos = sistema.getPedidosActivos();
+
+    QJsonArray arr;
+    for (const auto &p : pedidos)
+    {
+        QJsonObject po;
+        po.insert("id_pedido", p.id_pedido);
+        po.insert("cliente", QString::fromStdString(p.cliente));
+        po.insert("estado", QString::fromStdString(p.estado));
+        po.insert("total_final", p.total_final);
+
+        QJsonArray itemsArr;
+        for (const auto &it : p.items)
+        {
+            QJsonObject io;
+            io.insert("nombreProducto", QString::fromStdString(it.nombreProducto));
+            io.insert("cantidad", it.cantidad);
+            io.insert("precioUnitario", it.precioUnitario);
+            itemsArr.append(io);
+        }
+        po.insert("items", itemsArr);
+        arr.append(po);
+    }
+
+    QJsonObject resp;
+    resp.insert(Protocolo::KEY_STATUS, QString("OK"));
+    resp.insert(Protocolo::KEY_DATA, arr);
+
+    qDebug() << "CmdGetOrders: enviando respuesta con" << arr.size() << "pedidos";
+    NetworkProtocol::sendJson(clientSocket, resp);
+}

--- a/server/src/commands/CmdGetOrders.h
+++ b/server/src/commands/CmdGetOrders.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <memory>
+#include <QTcpSocket>
+#include <QJsonObject>
+
+#include "commands/IComandoServidor.h"
+
+class SistemaPedidos;
+
+class CmdGetOrders : public IComandoServidor
+{
+public:
+    CmdGetOrders() = default;
+    virtual ~CmdGetOrders() = default;
+
+    void ejecutar(QTcpSocket *clientSocket, const QJsonObject &payload, SistemaPedidos &sistema) override;
+};

--- a/server/src/core/SistemaPedidos.cpp
+++ b/server/src/core/SistemaPedidos.cpp
@@ -176,7 +176,6 @@ void SistemaPedidos::registrarObservador(std::shared_ptr<IObservadorCore> observ
             });
         if (it != observadores.end())
         {
-            observadores.push_back(observador);
             std::cout << "[SISTEMA] Observador ya registrado, omitiendo..." << std::endl;
             return;
         }

--- a/server/src/core/SistemaPedidos.cpp
+++ b/server/src/core/SistemaPedidos.cpp
@@ -12,6 +12,8 @@
 #include <iomanip>   // Formatear salida de precios
 #include "core/SistemaPedidos.h"
 #include "models/Persona.h"
+#include <QtSql/QSqlQuery>
+#include "db/DatabaseManager.h"
 #include "models/Cliente.h"
 #include "models/Producto.h"
 #include "models/ItemPedido.h"
@@ -29,8 +31,8 @@
  * @details Permite registrar personas, clientes, crear pedidos y notificar observadores (patrón Observer).
  */
 // Constructor
-SistemaPedidos::SistemaPedidos(std::shared_ptr<ProductRepository> prodRepo, std::shared_ptr<PedidoRepository> orderRepo)
-    : productRepository(prodRepo), pedidoRepository(orderRepo)
+SistemaPedidos::SistemaPedidos(std::shared_ptr<ProductRepository> prodRepo, std::shared_ptr<PedidoRepository> orderRepo, std::shared_ptr<repos::ClienteRepository> clienteRepo)
+    : productRepository(prodRepo), pedidoRepository(orderRepo), clienteRepository(clienteRepo)
 {
 }
 
@@ -254,6 +256,30 @@ void SistemaPedidos::finalizarPedido(
     const std::string &id_descuentos)
 {
     // Crear pedido completo usando la Factory
+    // Si el cliente no está registrado en memoria, intentar buscar en la BD y registrarlo
+    auto it = std::find_if(personas.begin(), personas.end(), [&](const std::shared_ptr<Persona> &p)
+                           {
+        auto c = std::dynamic_pointer_cast<Cliente>(p);
+        return c && c->getNombre() == cliente; });
+
+    if (it == personas.end())
+    {
+        // Intentar buscar en la BD por nombre
+        QSqlQuery q(DatabaseManager::instance().database());
+        q.prepare("SELECT id, name, tax_id FROM customers WHERE name = ?");
+        q.addBindValue(QString::fromStdString(cliente));
+        if (q.exec() && q.next())
+        {
+            int id = q.value(0).toInt();
+            QString name = q.value(1).toString();
+            QString tax = q.value(2).toString();
+            // Crear Cliente y registrar
+            auto nuevoCliente = CafeteriaFactory::crearCliente(id, name.toStdString(), tax.toStdString());
+            registrarPersona(nuevoCliente);
+            std::cout << "[API] Cliente registrado desde BD: " << name.toStdString() << std::endl;
+        }
+    }
+
     auto pedido = CafeteriaFactory::crearPedidoCompleto(
         proximoIdPersona++, // ID dummy, puedes mejorar esto
         cliente,

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -4,19 +4,31 @@
 #include "repositories/ProductRepository.h"
 #include "repositories/PedidoRepository.h"
 #include "NetworkServer.h"
+#include "db/DatabaseManager.h"
+#include "repositories/ClienteRepository.h"
 
 int main(int argc, char *argv[])
 {
     QCoreApplication app(argc, argv);
 
-    // Crear repositorios y cargar datos
+    // Crear repositorios y preparar la base de datos
     auto productRepository = std::make_shared<ProductRepository>();
+
+    // Inicializar tablas y datos de seed (útil en ejecución local/CI)
+    DatabaseManager::instance().inicializarTablas();
+    if (!DatabaseManager::instance().seedData())
+    {
+        qWarning() << "Warning: seedData() no se ejecutó correctamente. La BD puede estar vacía.";
+    }
+
+    // Cargar datos desde BD
     productRepository->loadFromDB();
 
     auto pedidoRepository = std::make_shared<PedidoRepository>();
+    auto clienteRepository = std::make_shared<repos::ClienteRepository>();
 
     // Inyectar repositorios en SistemaPedidos
-    SistemaPedidos sistema(productRepository, pedidoRepository);
+    SistemaPedidos sistema(productRepository, pedidoRepository, clienteRepository);
 
     // Crear y arrancar servidor de red (usa el subsistema de pedidos)
     // El servidor se registra como observador para recibir eventos del sistema

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -19,7 +19,10 @@ int main(int argc, char *argv[])
     SistemaPedidos sistema(productRepository, pedidoRepository);
 
     // Crear y arrancar servidor de red (usa el subsistema de pedidos)
-    NetworkServer servidor(&sistema);
+    // El servidor se registra como observador para recibir eventos del sistema
+    auto servidorPtr = std::make_shared<NetworkServer>(&sistema);
+    sistema.registrarObservador(servidorPtr);
+    // Nota: NetworkServer se mantiene en memoria a lo largo de la app
 
     // Mantener la app viva
     return app.exec();

--- a/server/src/repositories/ClienteRepository.cpp
+++ b/server/src/repositories/ClienteRepository.cpp
@@ -1,0 +1,47 @@
+#include "repositories/ClienteRepository.h"
+#include "models/Cliente.h"
+#include "db/DatabaseManager.h"
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlRecord>
+#include <QtSql/QSqlError>
+#include <QDebug>
+
+using namespace repos;
+
+ClienteRepository::ClienteRepository() {}
+ClienteRepository::~ClienteRepository() {}
+
+std::shared_ptr<Cliente> ClienteRepository::findByName(const std::string &name)
+{
+    QSqlQuery q(DatabaseManager::instance().database());
+    q.prepare("SELECT id, name, tax_id FROM customers WHERE name = ?");
+    q.addBindValue(QString::fromStdString(name));
+    if (!q.exec())
+    {
+        qWarning() << "ClienteRepository::findByName - query failed:" << q.lastError().text();
+        return nullptr;
+    }
+    if (q.next())
+    {
+        int id = q.value(0).toInt();
+        QString qname = q.value(1).toString();
+        QString tax = q.value(2).toString();
+        return std::make_shared<Cliente>(id, qname.toStdString(), tax.toStdString());
+    }
+    return nullptr;
+}
+
+std::shared_ptr<Cliente> ClienteRepository::create(const std::string &name, const std::string &taxId)
+{
+    QSqlQuery q(DatabaseManager::instance().database());
+    q.prepare("INSERT INTO customers (name, tax_id) VALUES (?, ?)");
+    q.addBindValue(QString::fromStdString(name));
+    q.addBindValue(QString::fromStdString(taxId));
+    if (!q.exec())
+    {
+        qWarning() << "ClienteRepository::create - insert failed:" << q.lastError().text();
+        return nullptr;
+    }
+    int id = q.lastInsertId().toInt();
+    return std::make_shared<Cliente>(id, name, taxId);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SERVER_SOURCES
     ../server/src/patterns/DescuentoPorcentaje.cpp 
     ../server/src/repositories/ProductRepository.cpp
     ../server/src/repositories/PedidoRepository.cpp
+    ../server/src/repositories/ClienteRepository.cpp
     # Incluir el proxy cliente para pruebas que lo requieren
     ../client/src/NetworkClientProxy.cpp
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,9 @@ file(GLOB TEST_SOURCES
     "test_*.cpp"
 )
 
+# Excluir testes Qt (se compilan por separado en network_proxy_tests)
+list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_network_proxy_async.cpp)
+
 file(GLOB DBMANAGER_SRC "../server/src/db/DatabaseManager.cpp")
 
 # Archivos del servidor necesarios para las pruebas
@@ -36,6 +39,8 @@ set(SERVER_SOURCES
     ../server/src/patterns/DescuentoPorcentaje.cpp 
     ../server/src/repositories/ProductRepository.cpp
     ../server/src/repositories/PedidoRepository.cpp
+    # Incluir el proxy cliente para pruebas que lo requieren
+    ../client/src/NetworkClientProxy.cpp
 )
 
 add_executable(unit_tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ file(GLOB TEST_SOURCES
 
 # Excluir testes Qt (se compilan por separado en network_proxy_tests)
 list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_network_proxy_async.cpp)
+list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_network_proxy_orders.cpp)
 
 file(GLOB DBMANAGER_SRC "../server/src/db/DatabaseManager.cpp")
 
@@ -22,6 +23,7 @@ set(SERVER_SOURCES
     ../server/src/NetworkServer.cpp
     ../server/src/CmdGetMenu.cpp
     ../server/src/CmdAddOrder.cpp
+    ../server/src/commands/CmdGetOrders.cpp
     ../server/src/models/Administrador.cpp
     ../server/src/models/Cliente.cpp
     ../server/src/models/Cocinero.cpp
@@ -79,6 +81,12 @@ add_executable(network_proxy_tests
     ../client/src/NetworkClientProxy.cpp
 )
 
+# Integration Qt test for broadcast
+add_executable(network_proxy_broadcast_integration
+    test_network_proxy_broadcast_integration.cpp
+    ../client/src/NetworkClientProxy.cpp
+)
+
 target_include_directories(network_proxy_tests PRIVATE
     ../client/src
     ../common/include
@@ -90,3 +98,60 @@ target_link_libraries(network_proxy_tests
 )
 
 add_test(NAME NetworkProxyAsyncTests COMMAND network_proxy_tests)
+
+# --- Broadcast integration test target ---
+target_include_directories(network_proxy_broadcast_integration PRIVATE
+    ../client/src
+    ../common/include
+)
+
+target_link_libraries(network_proxy_broadcast_integration
+    Qt6::Network
+    Qt6::Test
+)
+
+add_test(NAME NetworkProxyBroadcastIntegrationTests COMMAND network_proxy_broadcast_integration)
+
+# Test separado para verificar getPedidosActivos roundtrip
+add_executable(network_proxy_orders
+    test_network_proxy_orders.cpp
+    ../client/src/NetworkClientProxy.cpp
+)
+
+target_include_directories(network_proxy_orders PRIVATE
+    ../client/src
+    ../common/include
+)
+
+target_link_libraries(network_proxy_orders
+    Qt6::Network
+    Qt6::Test
+)
+
+add_test(NAME NetworkProxyOrdersTests COMMAND network_proxy_orders)
+
+# End-to-end test for ADD_ORDER -> EVT_NEW_ORDER
+add_executable(network_proxy_endtoend
+    test_network_proxy_endtoend.cpp
+    ../client/src/NetworkClientProxy.cpp
+    ../server/src/core/SistemaPedidos.cpp
+    ../server/src/repositories/ProductRepository.cpp
+    ../server/src/repositories/PedidoRepository.cpp
+    ../server/src/repositories/ClienteRepository.cpp
+    ../server/src/NetworkServer.cpp
+    ../server/src/CmdAddOrder.cpp
+    ../server/src/CmdGetMenu.cpp
+)
+
+target_include_directories(network_proxy_endtoend PRIVATE
+    ../client/src
+    ../server/include
+    ../common/include
+)
+
+target_link_libraries(network_proxy_endtoend
+    Qt6::Network
+    Qt6::Test
+)
+
+add_test(NAME NetworkProxyEndToEndTests COMMAND network_proxy_endtoend)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,10 +11,14 @@ file(GLOB TEST_SOURCES
 file(GLOB DBMANAGER_SRC "../server/src/db/DatabaseManager.cpp")
 
 # Archivos del servidor necesarios para las pruebas
+set(CMAKE_AUTOMOC ON)
 set(SERVER_SOURCES
     ../server/src/core/CafeteriaFactory.cpp
     ../server/src/core/MenuCafeteria.cpp
     ../server/src/core/SistemaPedidos.cpp
+    ../server/src/NetworkServer.cpp
+    ../server/src/CmdGetMenu.cpp
+    ../server/src/CmdAddOrder.cpp
     ../server/src/models/Administrador.cpp
     ../server/src/models/Cliente.cpp
     ../server/src/models/Cocinero.cpp
@@ -40,16 +44,23 @@ add_executable(unit_tests
     ${SERVER_SOURCES}
 )
 
+# For Qt's AUTOMOC: ensure headers with Q_OBJECT are processed for this target
+target_sources(unit_tests PRIVATE
+    ../server/include/NetworkServer.h
+)
+
 target_include_directories(unit_tests PRIVATE
     ../server/include
     ../common/include
 )
 
-find_package(Qt6 REQUIRED COMPONENTS Sql)
+find_package(Qt6 REQUIRED COMPONENTS Sql Network Test)
 target_link_libraries(unit_tests
     GTest::gtest_main
     GTest::gmock
     Qt6::Sql
+    Qt6::Network
+    Qt6::Test
 )
 
 gtest_discover_tests(unit_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,9 +8,11 @@ file(GLOB TEST_SOURCES
     "test_*.cpp"
 )
 
-# Excluir testes Qt (se compilan por separado en network_proxy_tests)
+# Excluir testes Qt (se compilan por separado en targets específicos)
 list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_network_proxy_async.cpp)
 list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_network_proxy_orders.cpp)
+list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_network_proxy_broadcast_integration.cpp)
+list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_network_proxy_endtoend.cpp)
 
 file(GLOB DBMANAGER_SRC "../server/src/db/DatabaseManager.cpp")
 
@@ -133,14 +135,13 @@ add_test(NAME NetworkProxyOrdersTests COMMAND network_proxy_orders)
 # End-to-end test for ADD_ORDER -> EVT_NEW_ORDER
 add_executable(network_proxy_endtoend
     test_network_proxy_endtoend.cpp
-    ../client/src/NetworkClientProxy.cpp
-    ../server/src/core/SistemaPedidos.cpp
-    ../server/src/repositories/ProductRepository.cpp
-    ../server/src/repositories/PedidoRepository.cpp
-    ../server/src/repositories/ClienteRepository.cpp
-    ../server/src/NetworkServer.cpp
-    ../server/src/CmdAddOrder.cpp
-    ../server/src/CmdGetMenu.cpp
+    ${SERVER_SOURCES}
+    ${DBMANAGER_SRC}
+)
+
+# For Qt's AUTOMOC: ensure headers with Q_OBJECT are processed for this target
+target_sources(network_proxy_endtoend PRIVATE
+    ../server/include/NetworkServer.h
 )
 
 target_include_directories(network_proxy_endtoend PRIVATE
@@ -149,9 +150,11 @@ target_include_directories(network_proxy_endtoend PRIVATE
     ../common/include
 )
 
+# Link same Qt components as unit_tests (server code uses SQL)
 target_link_libraries(network_proxy_endtoend
     Qt6::Network
     Qt6::Test
+    Qt6::Sql
 )
 
 add_test(NAME NetworkProxyEndToEndTests COMMAND network_proxy_endtoend)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,3 +64,23 @@ target_link_libraries(unit_tests
 )
 
 gtest_discover_tests(unit_tests)
+
+# ------------------------------------------------------------------
+# Tests for NetworkClientProxy (Qt Test based)
+# ------------------------------------------------------------------
+add_executable(network_proxy_tests
+    test_network_proxy_async.cpp
+    ../client/src/NetworkClientProxy.cpp
+)
+
+target_include_directories(network_proxy_tests PRIVATE
+    ../client/src
+    ../common/include
+)
+
+target_link_libraries(network_proxy_tests
+    Qt6::Network
+    Qt6::Test
+)
+
+add_test(NAME NetworkProxyAsyncTests COMMAND network_proxy_tests)

--- a/tests/test_clienterepository.cpp
+++ b/tests/test_clienterepository.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+
+#include "db/DatabaseManager.h"
+#include "repositories/ClienteRepository.h"
+#include "models/Cliente.h"
+
+using namespace repos;
+
+TEST(ClienteRepositoryTest, FindExistingReturnsCliente)
+{
+    DatabaseManager::instance().inicializarTablas();
+    ASSERT_TRUE(DatabaseManager::instance().seedData());
+
+    ClienteRepository repo;
+    auto c = repo.findByName("Carlos Juarez");
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->getNombre(), "Carlos Juarez");
+    EXPECT_EQ(c->getTelefono(), "12345678");
+}
+
+TEST(ClienteRepositoryTest, FindNonExistingReturnsNull)
+{
+    DatabaseManager::instance().inicializarTablas();
+    ASSERT_TRUE(DatabaseManager::instance().seedData());
+
+    ClienteRepository repo;
+    auto c = repo.findByName("NoExistente");
+    EXPECT_EQ(c, nullptr);
+}
+
+TEST(ClienteRepositoryTest, CreateInsertsAndCanBeFound)
+{
+    DatabaseManager::instance().inicializarTablas();
+    ASSERT_TRUE(DatabaseManager::instance().seedData());
+
+    ClienteRepository repo;
+    auto created = repo.create("Test Cliente", "99999999");
+    ASSERT_NE(created, nullptr);
+    EXPECT_EQ(created->getNombre(), "Test Cliente");
+    EXPECT_EQ(created->getTelefono(), "99999999");
+
+    auto found = repo.findByName("Test Cliente");
+    ASSERT_NE(found, nullptr);
+    EXPECT_EQ(found->getTelefono(), "99999999");
+}

--- a/tests/test_factory.cpp
+++ b/tests/test_factory.cpp
@@ -25,8 +25,8 @@ TEST(FactoryTest, CreateCliente)
 
 TEST(FactoryTest, CreateCocinero)
 {
-    // Incluir un puntero nulo para SistemaPedidos por simplicidad
-    SistemaPedidos sistema = SistemaPedidos(nullptr, nullptr);
+    // Incluir punteros nulos para SistemaPedidos por simplicidad
+    SistemaPedidos sistema = SistemaPedidos(nullptr, nullptr, nullptr);
     auto cocinero = CafeteriaFactory::crearCocinero(2, "Chef", "C001", &sistema);
 
     ASSERT_NE(cocinero, nullptr);

--- a/tests/test_integration_system.cpp
+++ b/tests/test_integration_system.cpp
@@ -51,7 +51,8 @@ TEST(IntegrationTest, FullSystemFlow)
     // Crear y cargar repositorio (o dejarlo vacio y usar agregarProducto)
     auto repo = std::make_shared<ProductRepository>();
     auto orderRepo = std::make_shared<PedidoRepository>();
-    SistemaPedidos sistema(repo, orderRepo);
+    auto clienteRepo = std::make_shared<repos::ClienteRepository>();
+    SistemaPedidos sistema(repo, orderRepo, clienteRepo);
 
     // 1. Setear Datos
     auto prod1 = std::make_shared<Producto>(1, "Cafe", 5.0, "Bebidas");

--- a/tests/test_network_broadcast.cpp
+++ b/tests/test_network_broadcast.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+#include <QCoreApplication>
+#include <QTcpSocket>
+#include <QTest>
+#include <QDataStream>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+
+#include "../server/include/NetworkServer.h"
+#include "../common/include/api/Protocolo.h"
+
+TEST(NetworkServerBroadcastTest, BroadcastReceivesEvtNewOrder)
+{
+    int argc = 0;
+    char **argv = nullptr;
+    QCoreApplication app(argc, argv);
+
+    NetworkServer server(nullptr);
+
+    QTcpSocket client;
+    client.connectToHost(QHostAddress::LocalHost, Protocolo::DEFAULT_PORT);
+    ASSERT_TRUE(client.waitForConnected(1000));
+
+    // Dar tiempo para que se registre
+    QTest::qWait(200);
+    EXPECT_EQ(server.getClientesConectadosCount(), 1);
+
+    // Llamar al handler del observador que difunde evento
+    server.onNuevosPedidosEnCola();
+
+    // Dar tiempo al event loop para procesar la emisión (especialmente en el mismo hilo)
+    QTest::qWait(100);
+
+    // Leer framing (dar un poco más de tiempo si fuera necesario)
+    QByteArray buffer;
+    bool ready = client.waitForReadyRead(2000);
+    if (ready)
+    {
+        buffer.append(client.readAll());
+    }
+    else
+    {
+        // No hubo readyRead, leer lo que esté pendiente (puede haberse producido sin señal)
+        QByteArray pending = client.readAll();
+        qDebug() << "No readyRead; bytesAvailable=" << client.bytesAvailable() << "pending=" << pending.size();
+        buffer.append(pending);
+    }
+
+    // Si no tenemos aún la cabecera, esperar un poco más
+    if (buffer.size() < 4)
+    {
+        ASSERT_TRUE(client.waitForReadyRead(1000));
+        buffer.append(client.readAll());
+    }
+
+    ASSERT_GE(buffer.size(), 4);
+    QByteArray hdr = buffer.left(4);
+    QDataStream ds(hdr);
+    ds.setByteOrder(QDataStream::BigEndian);
+    quint32 len = 0;
+    ds >> len;
+
+    // Asegurarse de tener el cuerpo completo
+    while ((quint32)(buffer.size() - 4) < len)
+    {
+        ASSERT_TRUE(client.waitForReadyRead(1000));
+        buffer.append(client.readAll());
+    }
+
+    QByteArray body = buffer.mid(4, (int)len);
+    ASSERT_EQ((quint32)body.size(), len);
+
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(body, &err);
+    ASSERT_EQ(err.error, QJsonParseError::NoError);
+    ASSERT_TRUE(doc.isObject());
+    QJsonObject obj = doc.object();
+    ASSERT_TRUE(obj.contains(Protocolo::KEY_CMD));
+    ASSERT_EQ(obj.value(Protocolo::KEY_CMD).toString(), Protocolo::EVT_NEW_ORDER);
+
+    client.disconnectFromHost();
+}

--- a/tests/test_network_proxy_async.cpp
+++ b/tests/test_network_proxy_async.cpp
@@ -22,7 +22,7 @@ public:
         emit notified();
     }
     void onPedidoTerminado(int /*id_pedido*/) override {}
-    void onError(const std::string &/*mensaje*/) override {}
+    void onError(const std::string & /*mensaje*/) override {}
 
     bool called;
 

--- a/tests/test_network_proxy_async.cpp
+++ b/tests/test_network_proxy_async.cpp
@@ -1,0 +1,103 @@
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QJsonObject>
+#include <QJsonArray>
+
+#include "../client/src/NetworkClientProxy.h"
+#include "../client/src/NetworkProtocol.h"
+#include "../common/include/api/Protocolo.h"
+
+// Simple observer stub that emits a Qt signal when notified
+class TestObservador : public QObject, public IObservadorCore
+{
+    Q_OBJECT
+public:
+    TestObservador() : called(false) {}
+
+    void onNuevosPedidosEnCola() override
+    {
+        called = true;
+        emit notified();
+    }
+    void onPedidoTerminado(int /*id_pedido*/) override {}
+    void onError(const std::string &/*mensaje*/) override {}
+
+    bool called;
+
+signals:
+    void notified();
+};
+
+class TestNetworkProxyAsync : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testRespuestaRecibida();
+    void testEvtNewOrder();
+};
+
+void TestNetworkProxyAsync::testRespuestaRecibida()
+{
+    // Crear proxy (sin servidor real, usaremos feedRawDataForTest)
+    NetworkClientProxy proxy(QStringLiteral("127.0.0.1"), 12345);
+
+    // Preparar spy
+    QSignalSpy spy(&proxy, SIGNAL(respuestaRecibida(QJsonObject)));
+
+    // Construir mensaje framed (4B BE + JSON)
+    QJsonObject resp;
+    resp.insert(Protocolo::KEY_STATUS, QStringLiteral("OK"));
+    resp.insert(Protocolo::KEY_DATA, QJsonArray());
+
+    QJsonDocument doc(resp);
+    QByteArray payload = doc.toJson(QJsonDocument::Compact);
+    QByteArray out;
+    QDataStream ds(&out, QIODevice::WriteOnly);
+    ds.setByteOrder(QDataStream::BigEndian);
+    ds << static_cast<quint32>(payload.size());
+    out.append(payload);
+
+    // Inyectar bytes y verificar emisión de señal
+    proxy.feedRawDataForTest(out);
+
+    QTRY_VERIFY(spy.count() >= 1);
+
+    // Verificar que el JSON recibido contiene status OK
+    QVariantList args = spy.takeFirst();
+    QJsonObject obj = args.at(0).value<QJsonObject>();
+    QCOMPARE(obj.value(Protocolo::KEY_STATUS).toString(), QStringLiteral("OK"));
+}
+
+void TestNetworkProxyAsync::testEvtNewOrder()
+{
+    NetworkClientProxy proxy(QStringLiteral("127.0.0.1"), 12345);
+
+    // Registrar observador stub
+    auto obs = std::make_shared<TestObservador>();
+    QSignalSpy spyObs(obs.get(), SIGNAL(notified()));
+    proxy.registrarObservador(obs);
+
+    // Construir evento framed
+    QJsonObject evt;
+    evt.insert(Protocolo::KEY_CMD, Protocolo::EVT_NEW_ORDER);
+    QJsonDocument doc(evt);
+    QByteArray payload = doc.toJson(QJsonDocument::Compact);
+    QByteArray out;
+    QDataStream ds(&out, QIODevice::WriteOnly);
+    ds.setByteOrder(QDataStream::BigEndian);
+    ds << static_cast<quint32>(payload.size());
+    out.append(payload);
+
+    // Inyectar evento
+    proxy.feedRawDataForTest(out);
+
+    // Esperar a que el observador sea notificado
+    QTRY_VERIFY(spyObs.count() >= 1);
+    QVERIFY(obs->called);
+}
+
+QTEST_MAIN(TestNetworkProxyAsync)
+#include "test_network_proxy_async.moc"

--- a/tests/test_network_proxy_broadcast_integration.cpp
+++ b/tests/test_network_proxy_broadcast_integration.cpp
@@ -1,0 +1,87 @@
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QCoreApplication>
+
+#include "../client/src/NetworkClientProxy.h"
+#include "../server/include/NetworkServer.h"
+#include "../common/include/api/Protocolo.h"
+
+// Simple observer stub that emits a Qt signal when notified (integration variant)
+class TestObservadorIntegration : public QObject, public IObservadorCore
+{
+    Q_OBJECT
+public:
+    TestObservadorIntegration() : called(false) {}
+
+    void onNuevosPedidosEnCola() override
+    {
+        called = true;
+        emit notified();
+    }
+    void onPedidoTerminado(int /*id_pedido*/) override {}
+    void onError(const std::string & /*mensaje*/) override {}
+
+    bool called;
+
+signals:
+    void notified();
+};
+
+class TestNetworkProxyBroadcastIntegration : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testBroadcastTriggersObservador();
+};
+
+void TestNetworkProxyBroadcastIntegration::testBroadcastTriggersObservador()
+{
+    int argc = 0;
+    char **argv = nullptr;
+    QCoreApplication app(argc, argv);
+
+    // Set up a simple server socket to accept connection and send the EVT
+    QTcpServer server;
+    QVERIFY(server.listen(QHostAddress::LocalHost, Protocolo::DEFAULT_PORT));
+
+    // Client proxy
+    NetworkClientProxy proxy(QStringLiteral(""), 0);
+    proxy.conectar(QStringLiteral("127.0.0.1"), Protocolo::DEFAULT_PORT);
+
+    // Wait for server to accept the connection
+    QTest::qWait(200);
+    QTcpSocket *serverSideSock = nullptr;
+    if (server.hasPendingConnections())
+        serverSideSock = server.nextPendingConnection();
+    QTRY_VERIFY(serverSideSock != nullptr);
+
+    // Setup observer
+    auto obs = std::make_shared<TestObservadorIntegration>();
+    QSignalSpy spy(obs.get(), SIGNAL(notified()));
+    proxy.registrarObservador(obs);
+
+    // Construct EVT_NEW_ORDER framed message and send to client
+    QJsonObject evt;
+    evt.insert(Protocolo::KEY_CMD, Protocolo::EVT_NEW_ORDER);
+    QJsonDocument doc(evt);
+    QByteArray payload = doc.toJson(QJsonDocument::Compact);
+    QByteArray out;
+    QDataStream ds(&out, QIODevice::WriteOnly);
+    ds.setByteOrder(QDataStream::BigEndian);
+    ds << static_cast<quint32>(payload.size());
+    out.append(payload);
+
+    serverSideSock->write(out);
+    serverSideSock->flush();
+    serverSideSock->waitForBytesWritten(2000);
+
+    // Wait for the proxy to process the incoming message and notify
+    QTRY_VERIFY(spy.count() >= 1);
+    QVERIFY(obs->called);
+}
+
+QTEST_MAIN(TestNetworkProxyBroadcastIntegration)
+#include "test_network_proxy_broadcast_integration.moc"

--- a/tests/test_network_proxy_endtoend.cpp
+++ b/tests/test_network_proxy_endtoend.cpp
@@ -1,0 +1,89 @@
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QCoreApplication>
+
+#include "../client/src/NetworkClientProxy.h"
+#include "../server/include/NetworkServer.h"
+#include "../server/include/core/SistemaPedidos.h"
+#include "../server/include/repositories/ProductRepository.h"
+#include "../server/include/repositories/PedidoRepository.h"
+#include "../server/include/repositories/ClienteRepository.h"
+#include "../common/include/api/Protocolo.h"
+
+// Observer stub for integration
+class TestObsEO : public QObject, public IObservadorCore
+{
+    Q_OBJECT
+public:
+    TestObsEO() : called(false) {}
+    void onNuevosPedidosEnCola() override
+    {
+        called = true;
+        emit notified();
+    }
+    void onPedidoTerminado(int) override {}
+    void onError(const std::string &) override {}
+    bool called;
+signals:
+    void notified();
+};
+
+class TestNetworkProxyEndToEnd : public QObject
+{
+    Q_OBJECT
+private slots:
+    void testAddOrderTriggersBroadcast();
+};
+
+void TestNetworkProxyEndToEnd::testAddOrderTriggersBroadcast()
+{
+    int argc = 0;
+    char **argv = nullptr;
+    QCoreApplication app(argc, argv);
+
+    // Sistema y servidor (crear repositorios requeridos)
+    auto repo = std::make_shared<ProductRepository>();
+    auto orderRepo = std::make_shared<PedidoRepository>();
+    auto clienteRepo = std::make_shared<repos::ClienteRepository>();
+    SistemaPedidos sistema(repo, orderRepo, clienteRepo);
+    NetworkServer server(&sistema);
+
+    // Registrar al servidor como observador del sistema (sin ownership)
+    sistema.registrarObservador(std::shared_ptr<IObservadorCore>(&server, [](IObservadorCore *) {}));
+
+    // Clientes/proxies
+    NetworkClientProxy proxy1(QStringLiteral(""), 0);
+    NetworkClientProxy proxy2(QStringLiteral(""), 0);
+
+    proxy1.conectar(QStringLiteral("127.0.0.1"), Protocolo::DEFAULT_PORT);
+    proxy2.conectar(QStringLiteral("127.0.0.1"), Protocolo::DEFAULT_PORT);
+
+    // Esperar conexiones aceptadas
+    QTest::qWait(200);
+    QTRY_VERIFY(server.getClientesConectadosCount() >= 2);
+
+    // Registrar observador en proxy2 y espiarlo
+    auto obs = std::make_shared<TestObsEO>();
+    QSignalSpy spy(obs.get(), SIGNAL(notified()));
+    proxy2.registrarObservador(obs);
+
+    // Construir pedido simple para enviar con proxy1
+    std::vector<ItemPedidoCrear> items;
+    ItemPedidoCrear it;
+    it.productoId = 1;
+    it.cantidad = 1;
+    items.push_back(it);
+
+    // Antes de enviar, clear any potential queued responses
+    // Enviar pedido (esto bloqueará hasta recibir respuesta OK o timeout)
+    proxy1.finalizarPedido("Cliente Test", items, "");
+
+    // Ahora el servidor debe haber notificado y difundir EVT_NEW_ORDER
+    QTRY_VERIFY(spy.count() >= 1);
+    QVERIFY(obs->called);
+}
+
+QTEST_MAIN(TestNetworkProxyEndToEnd)
+#include "test_network_proxy_endtoend.moc"

--- a/tests/test_network_proxy_orders.cpp
+++ b/tests/test_network_proxy_orders.cpp
@@ -1,0 +1,71 @@
+#include <QtTest/QtTest>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include "../client/src/NetworkClientProxy.h"
+#include "../client/src/NetworkProtocol.h"
+#include "../common/include/api/Protocolo.h"
+
+class TestNetworkProxyOrders : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testGetPedidosActivosRoundtrip();
+};
+
+void TestNetworkProxyOrders::testGetPedidosActivosRoundtrip()
+{
+    // Arrange a simple server that will accept the connection so the socket is considered connected
+    QTcpServer server;
+    QVERIFY(server.listen(QHostAddress::LocalHost, 0));
+    int port = server.serverPort();
+    QTcpSocket *clientSock = nullptr;
+    connect(&server, &QTcpServer::newConnection, [&]()
+            { clientSock = server.nextPendingConnection(); });
+
+    NetworkClientProxy proxy(QStringLiteral("127.0.0.1"), 0);
+    proxy.conectar(QStringLiteral("127.0.0.1"), static_cast<quint16>(port));
+    QTRY_VERIFY(clientSock != nullptr); // ensure server accepted the connection
+
+    QJsonObject resp;
+    resp.insert(Protocolo::KEY_STATUS, QStringLiteral("OK"));
+    QJsonArray dataArr;
+    QJsonObject ord;
+    ord.insert("id_pedido", 42);
+    ord.insert("cliente", "Test Cliente");
+    ord.insert("estado", "En Cola");
+    ord.insert("total_final", 12.5);
+    QJsonArray itemsArr;
+    QJsonObject it;
+    it.insert("nombreProducto", "Cafe Americano");
+    it.insert("cantidad", 1);
+    it.insert("precioUnitario", 5.5);
+    itemsArr.append(it);
+    ord.insert("items", itemsArr);
+    dataArr.append(ord);
+    resp.insert(Protocolo::KEY_DATA, dataArr);
+
+    // Construir respuesta framed y encolarla en el proxy antes de llamar al método
+    QJsonDocument docResp = QJsonDocument(resp);
+    QByteArray payload = docResp.toJson(QJsonDocument::Compact);
+    QByteArray out;
+    QDataStream ds(&out, QIODevice::WriteOnly);
+    ds.setByteOrder(QDataStream::BigEndian);
+    ds << static_cast<quint32>(payload.size());
+    out.append(payload);
+
+    // Inject the response directly into the proxy's buffer (simulating server reply)
+    proxy.feedRawDataForTest(out);
+
+    // Llamar a getPedidosActivos (enviarRequestYEsperarRespuesta verá la respuesta ya presente)
+    auto pedidos = proxy.getPedidosActivos();
+    QCOMPARE((int)pedidos.size(), 1);
+    QCOMPARE(pedidos[0].id_pedido, 42);
+    QCOMPARE(QString::fromStdString(pedidos[0].cliente), QString("Test Cliente"));
+    QCOMPARE(QString::fromStdString(pedidos[0].estado), QString("En Cola"));
+    QCOMPARE((int)pedidos[0].items.size(), 1);
+    QCOMPARE(QString::fromStdString(pedidos[0].items[0].nombreProducto), QString("Cafe Americano"));
+}
+
+QTEST_MAIN(TestNetworkProxyOrders)
+#include "test_network_proxy_orders.moc"

--- a/tests/test_network_server_clients.cpp
+++ b/tests/test_network_server_clients.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+#include <QCoreApplication>
+#include <QTcpSocket>
+#include <QTest>
+
+#include "../server/include/NetworkServer.h"
+#include "../common/include/api/Protocolo.h"
+
+TEST(NetworkServerClientsTest, ConnectDisconnectUpdatesList)
+{
+    int argc = 0;
+    char **argv = nullptr;
+    QCoreApplication app(argc, argv);
+
+    NetworkServer server(nullptr);
+
+    QTcpSocket client;
+    client.connectToHost(QHostAddress::LocalHost, Protocolo::DEFAULT_PORT);
+    ASSERT_TRUE(client.waitForConnected(1000));
+
+    QTest::qWait(200);
+    EXPECT_EQ(server.getClientesConectadosCount(), 1);
+
+    client.disconnectFromHost();
+    // Puede que el socket ya esté en UnconnectedState; esperar y aceptar ambos casos
+    bool disconnected = client.waitForDisconnected(1000);
+    if (!disconnected)
+    {
+        EXPECT_EQ(client.state(), QAbstractSocket::UnconnectedState);
+    }
+
+    QTest::qWait(200);
+    EXPECT_EQ(server.getClientesConectadosCount(), 0);
+}

--- a/tests/test_sistemapedidos.cpp
+++ b/tests/test_sistemapedidos.cpp
@@ -7,6 +7,7 @@
 #include "api/ApiDTOs.h"
 #include "repositories/ProductRepository.h"
 #include "repositories/PedidoRepository.h"
+#include "repositories/ClienteRepository.h"
 #include <QtSql/QSqlQuery>
 
 // Mock simple para MenuCafeteria y Producto si es necesario
@@ -21,8 +22,9 @@ TEST(SistemaPedidosTest, InicializarMenuCargaProductosDesdeDB)
     auto repo = std::make_shared<ProductRepository>();
     repo->loadFromDB();
     auto orderRepo = std::make_shared<PedidoRepository>();
+    auto clienteRepo = std::make_shared<repos::ClienteRepository>();
 
-    SistemaPedidos sistema(repo, orderRepo);
+    SistemaPedidos sistema(repo, orderRepo, clienteRepo);
 
     // Verificar que los productos del seed están presentes
     const auto &productos = sistema.getProductos();
@@ -49,8 +51,9 @@ TEST(SistemaPedidosTest, FinalizarPedidoPersisteEnDB)
     auto repo = std::make_shared<ProductRepository>();
     repo->loadFromDB();
     auto orderRepo = std::make_shared<PedidoRepository>();
+    auto clienteRepo = std::make_shared<repos::ClienteRepository>();
 
-    SistemaPedidos sistema(repo, orderRepo);
+    SistemaPedidos sistema(repo, orderRepo, clienteRepo);
 
     // Crear cliente y producto
     auto cliente = std::make_shared<Cliente>(1, "Carlos Juarez", "12345678");


### PR DESCRIPTION
## Objetivo

Añadir soporte de eventos en tiempo real (broadcast) en el sistema cliente‑servidor: cuando se finaliza un pedido por un cliente, el servidor difunde `EVT_NEW_ORDER` a todos los clientes conectados y las UIs actualizan automáticamente la vista de Cocina consultando `GET_ORDERS`. Además, robustez en cliente para diferenciar eventos push de respuestas a peticiones, y tests de integración que validan el comportamiento multi‑cliente.

## Cambios Principales

- Server:
  - Añadido `CmdGetOrders` para consultar pedidos activos.
  - Implementado `ClienteRepository` para gestión de clientes.
  - `NetworkServer::difundirEvento()` envía `EVT_NEW_ORDER` tras finalización de pedido.
- Client:
  - `NetworkClientProxy` detecta `EVT_NEW_ORDER` y notifica observador UI (debounce 50ms).
  - `enviarRequestYEsperarRespuesta` hace matching por forma del `response` para no consumir mensajes no relacionados.
  - `getPedidosActivos()` con retry y timeout mayor.
  - `MainWindow::procesarRespuesta()` valida `KEY_DATA` antes de repoblar el menú.
- Tests:
  - Tests Qt y gtest añadidos para validar broadcast y end-to-end.
- Docs:
  - `docs/WBS-3-Implementacion.md` y `docs/DiagramaRed.md` actualizados.

## Arquitectura Implementada (diagrama de secuencia)

```mermaid
sequenceDiagram
    participant C1 as Client 1 (CafeteriaClient)
    participant NS as NetworkServer
    participant SP as SistemaPedidos
    participant C2 as Client 2 (CafeteriaClient)
    participant NCP as NetworkClientProxy
    participant MW as MainWindow / Core Qt Adapter

    %% Flujo de Client 1
    C1->>NS: ADD_ORDER (framed JSON)
    NS->>SP: CmdAddOrder → applyOrder()
    SP-->>NS: notifica observadores
    NS-->>C1: difundirEvento
    NS-->>C2: EVT_NEW_ORDER (framed JSON a todos sockets)

    %% Flujo de Client 2
    C2->>NCP: recibe EVT_NEW_ORDER
    NCP->>NCP: detecta EVT_NEW_ORDER → debounce 50ms
    NCP->>MW: observador.onNuevosPedidosEnCola()

    MW->>NS: getPedidosActivos() → CMD_GET_ORDERS
    NS-->>MW: responde con lista completa

```

## Testing (cómo validar)

- Build y ejecutar todos los tests:
  - `cmake -S . -B build`
  - `cmake --build build -- -j$(nproc)`
  - `ctest --test-dir build --output-on-failure`
- Ejecutables clave:
  - `./build/tests/network_proxy_broadcast_integration -vs`
  - `./build/tests/network_proxy_endtoend -vs`
- Validación manual:
  1. `./build/server/CafeteriaServer`
  2. Abrir dos instancias de cliente: `./run_client.sh ./build/client/CafeteriaClient`
  3. En cliente A: finalizar un pedido.
  4. En cliente B: verificar logs y UI se refresca con la llamada a `GET_ORDERS`.

## Breaking Changes

- `SistemaPedidos` ahora puede depender de `ClienteRepository`: revisar lugares que lo instancien manualmente en tests/mains.

Closes #22
